### PR TITLE
Adding a configurable gitPath parameter to the build script

### DIFF
--- a/Start-Build.psm1
+++ b/Start-Build.psm1
@@ -106,7 +106,7 @@ function Invoke-Compile{
 					{
 						Write-Host "Undoing AssemblyInfo.cs file changes"
 						Import-Module "$baseModulePath\Undo-GitFileModifications.psm1"
-						Undo-GitFileModifications -fileName AssemblyInfo.cs
+						Undo-GitFileModifications -fileName AssemblyInfo.cs -gitPath $gitPath
 						Remove-Module Undo-GitFileModifications
 					}
 					

--- a/lib/powershell/modules/Undo-GitFileModifications.psm1
+++ b/lib/powershell/modules/Undo-GitFileModifications.psm1
@@ -31,7 +31,7 @@ function Undo-GitFileModifications{
 			[Parameter(
 				Position = 1,
 				Mandatory = $False )]
-				[string]$gitPath = "git.exe"
+				[string]$gitPath
 			)
 	Begin {
 			$DebugPreference = "Continue"
@@ -39,6 +39,12 @@ function Undo-GitFileModifications{
 	Process {
 				Try 
 				{
+					if ($gitPath -eq "")
+					{
+						$gitPath = "git.exe"
+					}
+					Write-Warning "Setting Git path to: $gitPath"
+					
 					Write-Host "Undoing all Git file modifications to $fileName files"
 					#Performs a Git CHECKOUT on the files modified during Set-BuildNumber
 					#A modules executing path is that of the calling script so this *should* always work. 

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,9 @@
-##Femah##
-Femah is a feature switching/toggling library, requiring minimal configuration.  Designed from day 1 to be enterprise scalable, our intention is to provide a robust and extensible framework to enable the .NET community to embrace the stable mainline (trunk) method of development and realise Continuous Delivery.
+#Femah#
+
+<a href="http://teamcity.codebetter.com/viewType.html?buildTypeId=bt972&guest=1"><img src="http://teamcity.codebetter.com/app/rest/builds/buildType:(id:bt972)/statusIcon" alt="teamcity.codebetter AutoBot build status"/></a>
+
+##Introduction##
+Femah is a feature switching/toggling library requiring minimal configuration.  Designed from day 1 to be enterprise scalable, our intention is to provide a robust and extensible library to enable the .NET community to embrace the [stable trunk method of development](http://paulhammant.com/2013/04/05/what-is-trunk-based-development/) and realise Continuous Delivery.
 
 ###MVP Goals###
 * Provide common feature switch types for majority of typical scenarios out of the box


### PR DESCRIPTION
Build script for Femah #6
Accidently missed passing the gitPath parameter to the PS module
responsible for undoing AssemblyInfo.cs modifications during the course
of the build.
