### PR TITLE
Provide simpler testing of FeatureSwitch Types

### DIFF
--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -46,7 +46,7 @@ namespace Femah.Core.Tests
             Assert.AreEqual(Encoding.UTF8, response.Object.ContentEncoding);
         }
 
-        [Test] 
+        [Test]
         public void ApiResponseReturns500IfCollectionInvalid()
         {
             //Arrange
@@ -68,153 +68,146 @@ namespace Femah.Core.Tests
         public void ApiGetResponseReturns200IfCollectionValid()
         {
             //Arrange
-                var testable = new TestableFemahApiHttpHandler();
-                
-                var httpContextMock = new Mock<HttpContextBase>();
-                httpContextMock.Setup(x => x.Request.Url)
-                    .Returns(new Uri("http://example.com/femah.axd/api/featureswitches"));
-                httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("GET");
+            var testable = new TestableFemahApiHttpHandler();
 
-                var response = new Mock<HttpResponseBase>();
-                response.SetupProperty(x => x.StatusCode);
-                httpContextMock.Setup(x => x.Response).Returns(response.Object);
+            var httpContextMock = new Mock<HttpContextBase>();
+            httpContextMock.Setup(x => x.Request.Url)
+                .Returns(new Uri("http://example.com/femah.axd/api/featureswitches"));
+            httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("GET");
 
-                var featureSwitches = new List<IFeatureSwitch>
+            var response = new Mock<HttpResponseBase>();
+            response.SetupProperty(x => x.StatusCode);
+            httpContextMock.Setup(x => x.Response).Returns(response.Object);
+
+            var featureSwitches = new List<IFeatureSwitch>
+            {
+                (new SimpleFeatureSwitch
                 {
-                    (new SimpleFeatureSwitch
-                    {
-                        Name = "TestFeatureSwitch",
-                        IsEnabled = false,
-                        FeatureType = "SimpleFeatureSwitch"
-                    })
-                };
+                    Name = "TestFeatureSwitch",
+                    IsEnabled = false,
+                    FeatureType = "SimpleFeatureSwitch"
+                })
+            };
 
-                var providerMock = new Mock<IFeatureSwitchProvider>();
-                providerMock.Setup(p => p.All())
-                    .Returns(featureSwitches);
+            var providerMock = new Mock<IFeatureSwitchProvider>();
+            providerMock.Setup(p => p.AllFeatureSwitches())
+                .Returns(featureSwitches);
 
-                Femah.Configure()
-                    .FeatureSwitchEnum(typeof(FeatureSwitches))
-                    .Provider(providerMock.Object)
-                    .Initialise();
-            
-                //Get the JSON response by intercepting the call to context.Response.Write
-                string responseContent = string.Empty;
-                response.Setup(x => x.Write(It.IsAny<string>())).Callback((string r) => { responseContent = r; });
+            Femah.Configure()
+                .FeatureSwitchEnum(typeof (FeatureSwitches))
+                .Provider(providerMock.Object)
+                .Initialise();
+
+            //Get the JSON response by intercepting the call to context.Response.Write
+            string responseContent = string.Empty;
+            response.Setup(x => x.Write(It.IsAny<string>())).Callback((string r) => { responseContent = r; });
 
             //Act
-                testable.ProcessRequest(httpContextMock.Object);
+            testable.ProcessRequest(httpContextMock.Object);
 
             //Assert
-                Assert.AreEqual(200, response.Object.StatusCode);
+            Assert.AreEqual(200, response.Object.StatusCode);
         }
 
         [Test]
         public void ApiGetResponseReturnsValidCollectionOfFeatureSwitches()
         {
             //Arrange
-                var testable = new TestableFemahApiHttpHandler();
+            var testable = new TestableFemahApiHttpHandler();
 
-                var httpContextMock = new Mock<HttpContextBase>();
-                httpContextMock.Setup(x => x.Request.Url)
-                    .Returns(new Uri("http://example.com/femah.axd/api/featureswitches"));
-                httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("GET");
+            var httpContextMock = new Mock<HttpContextBase>();
+            httpContextMock.Setup(x => x.Request.Url)
+                .Returns(new Uri("http://example.com/femah.axd/api/featureswitches"));
+            httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("GET");
 
-                var response = new Mock<HttpResponseBase>();
-                response.SetupProperty(x => x.StatusCode);
-                httpContextMock.Setup(x => x.Response).Returns(response.Object);
+            var response = new Mock<HttpResponseBase>();
+            response.SetupProperty(x => x.StatusCode);
+            httpContextMock.Setup(x => x.Response).Returns(response.Object);
 
-                var featureSwitches = new List<IFeatureSwitch>
-                    {
-                        (new SimpleFeatureSwitch
-                        {
-                            Name = "TestFeatureSwitch1",
-                            IsEnabled = false,
-                            FeatureType = "SimpleFeatureSwitch"
-                        }),
-                        (new SimpleFeatureSwitch
-                        {
-                            Name = "TestFeatureSwitch2",
-                            IsEnabled = false,
-                            FeatureType = "SimpleFeatureSwitch"
-                        })
-                    };
+            var featureSwitches = new List<IFeatureSwitch>
+            {
+                (new SimpleFeatureSwitch
+                {
+                    Name = "TestFeatureSwitch1",
+                    IsEnabled = false,
+                    FeatureType = "SimpleFeatureSwitch"
+                }),
+                (new SimpleFeatureSwitch
+                {
+                    Name = "TestFeatureSwitch2",
+                    IsEnabled = false,
+                    FeatureType = "SimpleFeatureSwitch"
+                })
+            };
 
-                //Serialise for comparing what we get back from the API
-                //using our extension method
-                var featureSwitchesJson = featureSwitches.ToJson();
-                //or directly with JSON.NET?
-                //var featureSwitchesJson = JsonConvert.SerializeObject(featureSwitches);
+            //Serialise for comparing what we get back from the API
+            //using our extension method
+            var featureSwitchesJson = featureSwitches.ToJson();
+            //or directly with JSON.NET?
+            //var featureSwitchesJson = JsonConvert.SerializeObject(featureSwitches);
 
-                var providerMock = new Mock<IFeatureSwitchProvider>();
-                providerMock.Setup(p => p.All())
-                    .Returns(featureSwitches);
+            var providerMock = new Mock<IFeatureSwitchProvider>();
+            providerMock.Setup(p => p.AllFeatureSwitches())
+                .Returns(featureSwitches);
 
-                Femah.Configure()
-                    .FeatureSwitchEnum(typeof(FeatureSwitches))
-                    .Provider(providerMock.Object)
-                    .Initialise();
+            Femah.Configure()
+                .FeatureSwitchEnum(typeof (FeatureSwitches))
+                .Provider(providerMock.Object)
+                .Initialise();
 
-                //Get the JSON response by intercepting the call to context.Response.Write
-                string responseContent = string.Empty;
-                response.Setup(x => x.Write(It.IsAny<string>())).Callback((string r) => { responseContent = r; });
+            //Get the JSON response by intercepting the call to context.Response.Write
+            string responseContent = string.Empty;
+            response.Setup(x => x.Write(It.IsAny<string>())).Callback((string r) => { responseContent = r; });
 
             //Act
-                testable.ProcessRequest(httpContextMock.Object);
+            testable.ProcessRequest(httpContextMock.Object);
 
             //Asert
-                Assert.AreEqual(responseContent, featureSwitchesJson);
+            Assert.AreEqual(responseContent, featureSwitchesJson);
 
         }
 
-        //[Test]
-//        public void ApiGetResponseReturns200AndValidCollectionOfFeatureSwitchTypes()
-//        {
-//            //Arrange
-//            var testable = new TestableFemahApiHttpHandler();
-//            var context = new Mock<HttpContextBase>();
-//            context.Setup(x => x.Request.Url)
-//                .Returns(new Uri("http://example.com/femah.axd/api/featureswitchtypes"));
-//            context.SetupGet(x => x.Request.HttpMethod).Returns("GET");
-//
-//            var response = new Mock<HttpResponseBase>();
-//            response.SetupProperty(x => x.StatusCode);
-//            response.SetupProperty(x => x.Output);
-//            context.Setup(x => x.Response).Returns(response.Object);
-//
-//            var providerMock = new Mock<IFeatureSwitchProvider>();
-//            Femah.Configure()
-//                .Provider(providerMock.Object)
-//                .FeatureSwitchEnum(typeof(FemahTests.FeatureSwitches))
-//                .Initialise();
-//
-//            //Get the SwitchTypes directly from the Femah service and convert them to JSON using our friend JSON.NET 
-//            //var switchTypes = Femah.AllSwitchTypes();
-//            //var serialisedSwitchTypes = JsonConvert.SerializeObject(switchTypes);
-//
-//            //Get the JSON response by intercepting the call to context.Response.Write
-//            string responseContent = string.Empty;
-//            response.Setup(x => x.Write(It.IsAny<string>())).Callback((string r) => { responseContent = r; });
-//
-//            //Act
-//            testable.ProcessRequest(context.Object);
-//
-//
-//            //Assert
-//            Assert.AreEqual(200, response.Object.StatusCode);
-//
-//            JsonSchema schema = JsonSchema.Parse(@"{
-//                      'type': 'object',
-//                      'properties': {
-//                        'name': {'type':'string'},
-//                        'hobbies': {'type': 'array'}
-//                      }
-//                    }");
-//
-//            JObject featureswitches = JObject.Parse(responseContent);
-//
-//            bool valid = featureswitches.IsValid(schema);
-//            Assert.IsTrue(valid);
-//        }
+        [Test]
+        public void ApiGetResponseReturnsValidCollectionOfFeatureSwitchTypes()
+        {
+            //Arrange
+            var testable = new TestableFemahApiHttpHandler();
+            var httpContextMock = new Mock<HttpContextBase>();
+            httpContextMock.Setup(x => x.Request.Url)
+                .Returns(new Uri("http://example.com/femah.axd/api/featureswitchtypes"));
+            httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("GET");
+
+            var response = new Mock<HttpResponseBase>();
+            response.SetupProperty(x => x.StatusCode);
+            httpContextMock.Setup(x => x.Response).Returns(response.Object);
+
+            var featureSwitchTypes = new List<Type> {typeof (SimpleFeatureSwitch)};
+
+            //Serialise for comparing what we get back from the API
+            //using our extension method
+            var featureSwitcheTypesJson = featureSwitchTypes.ToJson();
+            //or directly with JSON.NET?
+            //var featureSwitchesJson = JsonConvert.SerializeObject(featureSwitches);
+
+            var providerMock = new Mock<IFeatureSwitchProvider>();
+            providerMock.Setup(p => p.AllFeatureSwitchTypes())
+                .Returns(featureSwitchTypes);
+
+            Femah.Configure()
+                .Provider(providerMock.Object)
+                .Initialise();
+
+            //Get the JSON response by intercepting the call to context.Response.Write
+            string responseContent = string.Empty;
+            response.Setup(x => x.Write(It.IsAny<string>())).Callback((string r) => { responseContent = r; });
+
+            //Act
+            testable.ProcessRequest(httpContextMock.Object);
+
+            //Assert
+            //Assert.AreEqual(200, response.Object.StatusCode);
+            Assert.AreEqual(responseContent, featureSwitcheTypesJson);
+
+        }
     }
 }

--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -142,7 +142,7 @@ namespace Femah.Core.Tests
 
                 //Serialise for comparing what we get back from the API
                 //using our extension method
-                //var featureSwitchesJson = featureSwitches.ToJson();
+                var featureSwitchesJson = featureSwitches.ToJson();
                 //or directly with JSON.NET?
                 //var featureSwitchesJson = JsonConvert.SerializeObject(featureSwitches);
 
@@ -163,10 +163,7 @@ namespace Femah.Core.Tests
                 testable.ProcessRequest(httpContextMock.Object);
 
             //Asert
-                //var deserialisedFeatureSwitches = JsonConvert.DeserializeObject <List<FeatureSwitchBase>>(responseContent);
-                //var deserialisedFeatureSwitches = JsonConvert.DeserializeObject(responseContent, typeof(List<FeatureSwitchBase>), new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Objects });
-                var deserialisedFeatureSwitches = (List<SimpleFeatureSwitch>)JsonConvert.DeserializeObject(responseContent, typeof(List<SimpleFeatureSwitch>));
-                Assert.AreEqual(featureSwitches, deserialisedFeatureSwitches);
+                Assert.AreEqual(responseContent, featureSwitchesJson);
 
         }
 

--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -142,7 +142,7 @@ namespace Femah.Core.Tests
 
                 //Serialise for comparing what we get back from the API
                 //using our extension method
-                var featureSwitchesJson = featureSwitches.ToJson();
+                //var featureSwitchesJson = featureSwitches.ToJson();
                 //or directly with JSON.NET?
                 //var featureSwitchesJson = JsonConvert.SerializeObject(featureSwitches);
 
@@ -163,7 +163,10 @@ namespace Femah.Core.Tests
                 testable.ProcessRequest(httpContextMock.Object);
 
             //Asert
-                Assert.AreEqual(responseContent, featureSwitchesJson);
+                //var deserialisedFeatureSwitches = JsonConvert.DeserializeObject <List<FeatureSwitchBase>>(responseContent);
+                //var deserialisedFeatureSwitches = JsonConvert.DeserializeObject(responseContent, typeof(List<FeatureSwitchBase>), new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Objects });
+                var deserialisedFeatureSwitches = (List<SimpleFeatureSwitch>)JsonConvert.DeserializeObject(responseContent, typeof(List<SimpleFeatureSwitch>));
+                Assert.AreEqual(featureSwitches, deserialisedFeatureSwitches);
 
         }
 

--- a/Femah.Core/Femah.cs
+++ b/Femah.Core/Femah.cs
@@ -40,7 +40,7 @@ namespace Femah.Core
             _switches = Femah.LoadFeatureSwitchList(config.FeatureSwitchEnumType, Assembly.GetCallingAssembly());
 
             // Inialise the provider.
-            _provider.Initialise(_switches.Values.ToList());
+            _provider.Initialise(_switches.Values.ToList(), _switchTypes);
 
             _initialised = true;
 
@@ -152,7 +152,7 @@ namespace Femah.Core
         /// <returns></returns>
         internal static List<IFeatureSwitch> AllFeatures()
         {
-            return _provider.All();
+            return _provider.AllFeatureSwitches();
         }
 
         /// <summary>
@@ -161,7 +161,8 @@ namespace Femah.Core
         /// <returns></returns>
         internal static List<Type> AllSwitchTypes()
         {
-            return _switchTypes;
+            //return _switchTypes;
+            return _provider.AllFeatureSwitchTypes();
         }
 
         /// <summary>

--- a/Femah.Core/IFeatureSwitchProvider.cs
+++ b/Femah.Core/IFeatureSwitchProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Femah.Core
 {
@@ -11,7 +12,8 @@ namespace Femah.Core
         /// Initialise the provider, given the names of the feature switches.
         /// </summary>
         /// <param name="featureSwitches">Names of the feature switches in the application.</param>
-        void Initialise(IEnumerable<string> featureSwitches);
+        /// <param name="featureSwitchTypes">The feature switch types in the application.</param>
+        void Initialise(IEnumerable<string> featureSwitches, List<Type> featureSwitchTypes );
 
         /// <summary>
         /// Get a feature switch.
@@ -30,6 +32,8 @@ namespace Femah.Core
         /// Return all feature switches.
         /// </summary>
         /// <returns>A list of zero or more instances of IFeatureSwitch</returns>
-        List<IFeatureSwitch> All();
+        List<IFeatureSwitch> AllFeatureSwitches();
+
+        List<Type> AllFeatureSwitchTypes();
     }
 }

--- a/Femah.Core/Providers/InProcProvider.cs
+++ b/Femah.Core/Providers/InProcProvider.cs
@@ -11,12 +11,14 @@ namespace Femah.Core.Providers
     public class InProcProvider : IFeatureSwitchProvider
     {
         static List<IFeatureSwitch> _featureSwitches = new List<IFeatureSwitch>();
+        static List<Type> _featureSwitchtypes = null;
 
         /// <summary>
         /// Initialise the feature switches in the provider.
         /// </summary>
         /// <param name="featureSwitches"></param>
-        public void Initialise( IEnumerable<string> featureSwitches )
+        /// <param name="featureSwitchTypes">The feature switch types in the application.</param>
+        public void Initialise( IEnumerable<string> featureSwitches, List<Type> featureSwitchTypes )
         {
             _featureSwitches.Clear();
 
@@ -24,6 +26,9 @@ namespace Femah.Core.Providers
             {
                 _featureSwitches.Add(new SimpleFeatureSwitch { Name = featureSwitch, IsEnabled = false, FeatureType = featureSwitch.GetType().Name});
             }
+
+            _featureSwitchtypes = featureSwitchTypes;
+
         }
 
         /// <summary>
@@ -55,9 +60,14 @@ namespace Femah.Core.Providers
         /// Return all feature switches in the provider.
         /// </summary>
         /// <returns></returns>
-        public List<IFeatureSwitch> All()
+        public List<IFeatureSwitch> AllFeatureSwitches()
         {
             return _featureSwitches;
+        }
+
+        public List<Type> AllFeatureSwitchTypes()
+        {
+            return _featureSwitchtypes;
         }
     }
 }

--- a/Femah.Core/Providers/SqlServerProvider.cs
+++ b/Femah.Core/Providers/SqlServerProvider.cs
@@ -37,7 +37,7 @@ namespace Femah.Core.Providers
     {
         private string _connectionString;
         private string _tableName = "femahSwitches";
-
+        static List<Type> _featureSwitchtypes = null;
 
         /// <summary>
         /// Configure the SqlServerProvider.
@@ -54,7 +54,8 @@ namespace Femah.Core.Providers
         /// Initialise the provider, given the names of the feature switches.
         /// </summary>
         /// <param name="featureSwitches">Names of the feature switches in the application.</param>
-        public void Initialise(IEnumerable<string> featureSwitches)
+        /// <param name="featureSwitchTypes">The feature switch types in the application.</param>
+        public void Initialise(IEnumerable<string> featureSwitches, List<Type> featureSwitchTypes)
         {
             using (var conn = new SqlConnection(_connectionString))
             {
@@ -74,7 +75,11 @@ namespace Femah.Core.Providers
                 // Remove any feature switches from database that aren't valid feature switches.
                 DeleteUnlistedSwitches(featureSwitches, conn);
             }
+
+            _featureSwitchtypes.Clear();
+            _featureSwitchtypes = featureSwitchTypes;
         }
+
 
         /// <summary>
         /// Get a feature switch.
@@ -111,7 +116,7 @@ namespace Femah.Core.Providers
         /// Return all feature switches.
         /// </summary>
         /// <returns>A list of zero or more instances of IFeatureSwitch</returns>
-        public List<IFeatureSwitch> All()
+        public List<IFeatureSwitch> AllFeatureSwitches()
         {
             List<IFeatureSwitch> featureSwitches;
 
@@ -122,6 +127,11 @@ namespace Femah.Core.Providers
             }
 
             return featureSwitches;
+        }
+
+        public List<Type> AllFeatureSwitchTypes()
+        {
+            return _featureSwitchtypes;
         }
 
         #endregion

--- a/TestResult.xml
+++ b/TestResult.xml
@@ -1,39 +1,51 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--This file represents the results of running a test suite-->
-<test-results name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" total="13" errors="0" failures="0" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2014-01-14" time="12:58:34">
+<test-results name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" total="21" errors="0" failures="0" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2014-02-10" time="17:13:58">
   <environment nunit-version="2.6.3.13283" clr-version="2.0.50727.7905" os-version="Microsoft Windows NT 6.2.9200.0" platform="Win32NT" cwd="C:\Development\GitHub\femah" machine-name="R9-FV2Z5-VM1" user="LHolman1" user-domain="HITACHICC" />
   <culture-info current-culture="en-GB" current-uiculture="en-GB" />
-  <test-suite type="Assembly" name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" executed="True" result="Success" success="True" time="1.238" asserts="0">
+  <test-suite type="Assembly" name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" executed="True" result="Success" success="True" time="1.944" asserts="0">
     <results>
-      <test-suite type="Namespace" name="Femah" executed="True" result="Success" success="True" time="1.215" asserts="0">
+      <test-suite type="Namespace" name="Femah" executed="True" result="Success" success="True" time="1.919" asserts="0">
         <results>
-          <test-suite type="Namespace" name="Core" executed="True" result="Success" success="True" time="1.212" asserts="0">
+          <test-suite type="Namespace" name="Core" executed="True" result="Success" success="True" time="1.916" asserts="0">
             <results>
-              <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.209" asserts="0">
+              <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.913" asserts="0">
                 <results>
-                  <test-suite type="TestFixture" name="FemahTests" executed="True" result="Success" success="True" time="0.728" asserts="0">
+                  <test-suite type="TestFixture" name="FemahApiTests" executed="True" result="Success" success="True" time="1.491" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextAreSwallowed" executed="True" result="Success" success="True" time="0.623" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextFactoryAreSwallowed" executed="True" result="Success" success="True" time="0.003" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByFeatureSwitchesAreSwallowed" executed="True" result="Success" success="True" time="0.025" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturns200IfCollectionValid" executed="True" result="Success" success="True" time="1.390" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturnsValidCollectionOfFeatureSwitches" executed="True" result="Success" success="True" time="0.018" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturnsValidCollectionOfFeatureSwitchTypes" executed="True" result="Success" success="True" time="0.031" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiResponseReturns500IfCollectionInvalid" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiResponseSetsCorrectContentTypeAndEncoding" executed="True" result="Success" success="True" time="0.014" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="FemahTests" executed="True" result="Success" success="True" time="0.225" asserts="0">
+                    <results>
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextAreSwallowed" executed="True" result="Success" success="True" time="0.016" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextFactoryAreSwallowed" executed="True" result="Success" success="True" time="0.004" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByFeatureSwitchesAreSwallowed" executed="True" result="Success" success="True" time="0.023" asserts="0" />
                       <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByProviderAreSwallowed" executed="True" result="Success" success="True" time="0.003" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithInvalidFeatureSwitchIdDoesntThrowException" executed="True" result="Success" success="True" time="0.041" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithoutInitialisingDoesntThrowException" executed="True" result="Success" success="True" time="0.007" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithInvalidFeatureSwitchIdDoesntThrowException" executed="True" result="Success" success="True" time="0.044" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithoutInitialisingDoesntThrowException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonMatchingDeserialisedType" executed="True" result="Success" success="True" time="0.111" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonWithExtraFieldNotPresentTargetType" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonWithMissingFieldFromTargetType" executed="True" result="Success" success="True" time="0.007" asserts="1" />
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="PercentageFeatureSwitchTests" executed="True" result="Success" success="True" time="0.426" asserts="0">
+                  <test-suite type="TestFixture" name="PercentageFeatureSwitchTests" executed="True" result="Success" success="True" time="0.145" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.IsOnIffRandomNumberBelowThreshold" executed="True" result="Success" success="True" time="0.358" asserts="0" />
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.SetsCookieWhenNoCookieExists" executed="True" result="Success" success="True" time="0.030" asserts="0" />
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.UsesValueFromCookieWhenCookieExists" executed="True" result="Success" success="True" time="0.034" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.IsOnIffRandomNumberBelowThreshold" executed="True" result="Success" success="True" time="0.086" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.SetsCookieWhenNoCookieExists" executed="True" result="Success" success="True" time="0.027" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.UsesValueFromCookieWhenCookieExists" executed="True" result="Success" success="True" time="0.028" asserts="0" />
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="RoleBasedFeatureSwitchTests" executed="True" result="Success" success="True" time="0.043" asserts="0">
+                  <test-suite type="TestFixture" name="RoleBasedFeatureSwitchTests" executed="True" result="Success" success="True" time="0.039" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenNoRoles" executed="True" result="Success" success="True" time="0.023" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenNoRoles" executed="True" result="Success" success="True" time="0.021" asserts="0" />
                       <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenUserNotInRole" executed="True" result="Success" success="True" time="0.005" asserts="0" />
                       <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInOneOfManyRoles" executed="True" result="Success" success="True" time="0.004" asserts="0" />
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInRole" executed="True" result="Success" success="True" time="0.005" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInRole" executed="True" result="Success" success="True" time="0.004" asserts="0" />
                     </results>
                   </test-suite>
                 </results>

--- a/TestResult.xml
+++ b/TestResult.xml
@@ -1,39 +1,59 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--This file represents the results of running a test suite-->
-<test-results name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" total="13" errors="0" failures="0" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2014-01-14" time="12:58:34">
+<test-results name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" total="20" errors="0" failures="1" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2014-02-05" time="22:23:54">
   <environment nunit-version="2.6.3.13283" clr-version="2.0.50727.7905" os-version="Microsoft Windows NT 6.2.9200.0" platform="Win32NT" cwd="C:\Development\GitHub\femah" machine-name="R9-FV2Z5-VM1" user="LHolman1" user-domain="HITACHICC" />
   <culture-info current-culture="en-GB" current-uiculture="en-GB" />
-  <test-suite type="Assembly" name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" executed="True" result="Success" success="True" time="1.238" asserts="0">
+  <test-suite type="Assembly" name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" executed="True" result="Failure" success="False" time="2.430" asserts="0">
     <results>
-      <test-suite type="Namespace" name="Femah" executed="True" result="Success" success="True" time="1.215" asserts="0">
+      <test-suite type="Namespace" name="Femah" executed="True" result="Failure" success="False" time="2.402" asserts="0">
         <results>
-          <test-suite type="Namespace" name="Core" executed="True" result="Success" success="True" time="1.212" asserts="0">
+          <test-suite type="Namespace" name="Core" executed="True" result="Failure" success="False" time="2.400" asserts="0">
             <results>
-              <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.209" asserts="0">
+              <test-suite type="Namespace" name="Tests" executed="True" result="Failure" success="False" time="2.396" asserts="0">
                 <results>
-                  <test-suite type="TestFixture" name="FemahTests" executed="True" result="Success" success="True" time="0.728" asserts="0">
+                  <test-suite type="TestFixture" name="FemahApiTests" executed="True" result="Failure" success="False" time="1.987" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextAreSwallowed" executed="True" result="Success" success="True" time="0.623" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextFactoryAreSwallowed" executed="True" result="Success" success="True" time="0.003" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByFeatureSwitchesAreSwallowed" executed="True" result="Success" success="True" time="0.025" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturns200IfCollectionValid" executed="True" result="Success" success="True" time="1.763" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturnsValidCollectionOfFeatureSwitches" executed="True" result="Failure" success="False" time="0.157" asserts="1">
+                        <failure>
+                          <message><![CDATA[  Expected is <System.Collections.Generic.List`1[Femah.Core.IFeatureSwitch]> with 2 elements, actual is <System.Collections.Generic.List`1[Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch]> with 2 elements
+  Values differ at index [0]
+  Expected: <Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch>
+  But was:  <Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch>
+]]></message>
+                          <stack-trace><![CDATA[]]></stack-trace>
+                        </failure>
+                      </test-case>
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiResponseReturns500IfCollectionInvalid" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiResponseSetsCorrectContentTypeAndEncoding" executed="True" result="Success" success="True" time="0.023" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="FemahTests" executed="True" result="Success" success="True" time="0.172" asserts="0">
+                    <results>
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextAreSwallowed" executed="True" result="Success" success="True" time="0.019" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextFactoryAreSwallowed" executed="True" result="Success" success="True" time="0.004" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByFeatureSwitchesAreSwallowed" executed="True" result="Success" success="True" time="0.026" asserts="0" />
                       <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByProviderAreSwallowed" executed="True" result="Success" success="True" time="0.003" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithInvalidFeatureSwitchIdDoesntThrowException" executed="True" result="Success" success="True" time="0.041" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithoutInitialisingDoesntThrowException" executed="True" result="Success" success="True" time="0.007" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithInvalidFeatureSwitchIdDoesntThrowException" executed="True" result="Success" success="True" time="0.065" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithoutInitialisingDoesntThrowException" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonMatchingDeserialisedType" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonWithExtraFieldNotPresentTargetType" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonWithMissingFieldFromTargetType" executed="True" result="Success" success="True" time="0.011" asserts="1" />
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="PercentageFeatureSwitchTests" executed="True" result="Success" success="True" time="0.426" asserts="0">
+                  <test-suite type="TestFixture" name="PercentageFeatureSwitchTests" executed="True" result="Success" success="True" time="0.174" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.IsOnIffRandomNumberBelowThreshold" executed="True" result="Success" success="True" time="0.358" asserts="0" />
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.SetsCookieWhenNoCookieExists" executed="True" result="Success" success="True" time="0.030" asserts="0" />
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.UsesValueFromCookieWhenCookieExists" executed="True" result="Success" success="True" time="0.034" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.IsOnIffRandomNumberBelowThreshold" executed="True" result="Success" success="True" time="0.096" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.SetsCookieWhenNoCookieExists" executed="True" result="Success" success="True" time="0.041" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.UsesValueFromCookieWhenCookieExists" executed="True" result="Success" success="True" time="0.030" asserts="0" />
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="RoleBasedFeatureSwitchTests" executed="True" result="Success" success="True" time="0.043" asserts="0">
+                  <test-suite type="TestFixture" name="RoleBasedFeatureSwitchTests" executed="True" result="Success" success="True" time="0.047" asserts="0">
                     <results>
                       <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenNoRoles" executed="True" result="Success" success="True" time="0.023" asserts="0" />
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenUserNotInRole" executed="True" result="Success" success="True" time="0.005" asserts="0" />
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInOneOfManyRoles" executed="True" result="Success" success="True" time="0.004" asserts="0" />
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInRole" executed="True" result="Success" success="True" time="0.005" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenUserNotInRole" executed="True" result="Success" success="True" time="0.006" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInOneOfManyRoles" executed="True" result="Success" success="True" time="0.005" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInRole" executed="True" result="Success" success="True" time="0.006" asserts="0" />
                     </results>
                   </test-suite>
                 </results>

--- a/TestResult.xml
+++ b/TestResult.xml
@@ -1,59 +1,39 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--This file represents the results of running a test suite-->
-<test-results name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" total="20" errors="0" failures="1" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2014-02-05" time="22:23:54">
+<test-results name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" total="13" errors="0" failures="0" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2014-01-14" time="12:58:34">
   <environment nunit-version="2.6.3.13283" clr-version="2.0.50727.7905" os-version="Microsoft Windows NT 6.2.9200.0" platform="Win32NT" cwd="C:\Development\GitHub\femah" machine-name="R9-FV2Z5-VM1" user="LHolman1" user-domain="HITACHICC" />
   <culture-info current-culture="en-GB" current-uiculture="en-GB" />
-  <test-suite type="Assembly" name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" executed="True" result="Failure" success="False" time="2.430" asserts="0">
+  <test-suite type="Assembly" name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" executed="True" result="Success" success="True" time="1.238" asserts="0">
     <results>
-      <test-suite type="Namespace" name="Femah" executed="True" result="Failure" success="False" time="2.402" asserts="0">
+      <test-suite type="Namespace" name="Femah" executed="True" result="Success" success="True" time="1.215" asserts="0">
         <results>
-          <test-suite type="Namespace" name="Core" executed="True" result="Failure" success="False" time="2.400" asserts="0">
+          <test-suite type="Namespace" name="Core" executed="True" result="Success" success="True" time="1.212" asserts="0">
             <results>
-              <test-suite type="Namespace" name="Tests" executed="True" result="Failure" success="False" time="2.396" asserts="0">
+              <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.209" asserts="0">
                 <results>
-                  <test-suite type="TestFixture" name="FemahApiTests" executed="True" result="Failure" success="False" time="1.987" asserts="0">
+                  <test-suite type="TestFixture" name="FemahTests" executed="True" result="Success" success="True" time="0.728" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturns200IfCollectionValid" executed="True" result="Success" success="True" time="1.763" asserts="1" />
-                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturnsValidCollectionOfFeatureSwitches" executed="True" result="Failure" success="False" time="0.157" asserts="1">
-                        <failure>
-                          <message><![CDATA[  Expected is <System.Collections.Generic.List`1[Femah.Core.IFeatureSwitch]> with 2 elements, actual is <System.Collections.Generic.List`1[Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch]> with 2 elements
-  Values differ at index [0]
-  Expected: <Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch>
-  But was:  <Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch>
-]]></message>
-                          <stack-trace><![CDATA[]]></stack-trace>
-                        </failure>
-                      </test-case>
-                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiResponseReturns500IfCollectionInvalid" executed="True" result="Success" success="True" time="0.010" asserts="1" />
-                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiResponseSetsCorrectContentTypeAndEncoding" executed="True" result="Success" success="True" time="0.023" asserts="2" />
-                    </results>
-                  </test-suite>
-                  <test-suite type="TestFixture" name="FemahTests" executed="True" result="Success" success="True" time="0.172" asserts="0">
-                    <results>
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextAreSwallowed" executed="True" result="Success" success="True" time="0.019" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextFactoryAreSwallowed" executed="True" result="Success" success="True" time="0.004" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByFeatureSwitchesAreSwallowed" executed="True" result="Success" success="True" time="0.026" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextAreSwallowed" executed="True" result="Success" success="True" time="0.623" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextFactoryAreSwallowed" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByFeatureSwitchesAreSwallowed" executed="True" result="Success" success="True" time="0.025" asserts="0" />
                       <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByProviderAreSwallowed" executed="True" result="Success" success="True" time="0.003" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithInvalidFeatureSwitchIdDoesntThrowException" executed="True" result="Success" success="True" time="0.065" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithoutInitialisingDoesntThrowException" executed="True" result="Success" success="True" time="0.002" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonMatchingDeserialisedType" executed="True" result="Success" success="True" time="0.011" asserts="1" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonWithExtraFieldNotPresentTargetType" executed="True" result="Success" success="True" time="0.005" asserts="1" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonWithMissingFieldFromTargetType" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithInvalidFeatureSwitchIdDoesntThrowException" executed="True" result="Success" success="True" time="0.041" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithoutInitialisingDoesntThrowException" executed="True" result="Success" success="True" time="0.007" asserts="0" />
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="PercentageFeatureSwitchTests" executed="True" result="Success" success="True" time="0.174" asserts="0">
+                  <test-suite type="TestFixture" name="PercentageFeatureSwitchTests" executed="True" result="Success" success="True" time="0.426" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.IsOnIffRandomNumberBelowThreshold" executed="True" result="Success" success="True" time="0.096" asserts="0" />
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.SetsCookieWhenNoCookieExists" executed="True" result="Success" success="True" time="0.041" asserts="0" />
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.UsesValueFromCookieWhenCookieExists" executed="True" result="Success" success="True" time="0.030" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.IsOnIffRandomNumberBelowThreshold" executed="True" result="Success" success="True" time="0.358" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.SetsCookieWhenNoCookieExists" executed="True" result="Success" success="True" time="0.030" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.UsesValueFromCookieWhenCookieExists" executed="True" result="Success" success="True" time="0.034" asserts="0" />
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="RoleBasedFeatureSwitchTests" executed="True" result="Success" success="True" time="0.047" asserts="0">
+                  <test-suite type="TestFixture" name="RoleBasedFeatureSwitchTests" executed="True" result="Success" success="True" time="0.043" asserts="0">
                     <results>
                       <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenNoRoles" executed="True" result="Success" success="True" time="0.023" asserts="0" />
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenUserNotInRole" executed="True" result="Success" success="True" time="0.006" asserts="0" />
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInOneOfManyRoles" executed="True" result="Success" success="True" time="0.005" asserts="0" />
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInRole" executed="True" result="Success" success="True" time="0.006" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenUserNotInRole" executed="True" result="Success" success="True" time="0.005" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInOneOfManyRoles" executed="True" result="Success" success="True" time="0.004" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInRole" executed="True" result="Success" success="True" time="0.005" asserts="0" />
                     </results>
                   </test-suite>
                 </results>

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,8 @@
 #Femah#
 
+<a href="https://github.com/lloydstone/femah"><img src="https://f.cloud.github.com/assets/362197/2124054/b67ee748-9237-11e3-8b44-ff2bd7fba50c.png
+" alt="Femah project home logo"/></a>
+
 <a href="http://teamcity.jetbrains.com/viewType.html?buildTypeId=NetCommunityProjects_Femah_Femah&guest=1"><img src="http://teamcity.jetbrains.com/app/rest/builds/buildType:(id:NetCommunityProjects_Femah_Femah)/statusIcon" alt="teamcity.jetbrains Femah build status"/></a>
 
 ##Introduction##

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,5 @@
 #Femah#
 
-<a href="https://github.com/lloydstone/femah"><img src="https://f.cloud.github.com/assets/362197/2124054/b67ee748-9237-11e3-8b44-ff2bd7fba50c.png
-" alt="Femah project home logo"/></a>
-
 <a href="http://teamcity.jetbrains.com/viewType.html?buildTypeId=NetCommunityProjects_Femah_Femah&guest=1"><img src="http://teamcity.jetbrains.com/app/rest/builds/buildType:(id:NetCommunityProjects_Femah_Femah)/statusIcon" alt="teamcity.jetbrains Femah build status"/></a>
 
 ##Introduction##

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,6 @@
 #Femah#
 
-<a href="https://github.com/lloydstone/femah"><img src="https://f.cloud.github.com/assets/362197/2124054/b67ee748-9237-11e3-8b44-ff2bd7fba50c.png
-" alt="Femah project home logo"/></a>
+<a href="https://github.com/lloydstone/femah"><img src="https://f.cloud.github.com/assets/362197/2124054/b67ee748-9237-11e3-8b44-ff2bd7fba50c.png" alt="Femah project home logo"/></a>
 
 <a href="http://teamcity.jetbrains.com/viewType.html?buildTypeId=NetCommunityProjects_Femah_Femah&guest=1"><img src="http://teamcity.jetbrains.com/app/rest/builds/buildType:(id:NetCommunityProjects_Femah_Femah)/statusIcon" alt="teamcity.jetbrains Femah build status"/></a>
 


### PR DESCRIPTION
- # 24 - API integration to support Admin UI and basic use cases. To allow testing of FeatureSwitchType retrieval (AllSwitchTypes) I've added AllFeatureSwitchTypes() to IFeatureSwitchProvider, allowing for simpler mocking of Types in tests.
- Also added link to femah logo to readme
