### PR TITLE
Provide simpler testing of FeatureSwitch Types

### DIFF
--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -190,8 +190,8 @@ namespace Femah.Core.Tests
             //var featureSwitchesJson = JsonConvert.SerializeObject(featureSwitches);
 
             var providerMock = new Mock<IFeatureSwitchProvider>();
-            providerMock.Setup(p => p.AllFeatureSwitchTypes())
-                .Returns(featureSwitchTypes);
+            //providerMock.Setup(p => p.AllFeatureSwitchTypes())
+            //    .Returns(featureSwitchTypes);
 
             Femah.Configure()
                 .Provider(providerMock.Object)

--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -206,7 +206,7 @@ namespace Femah.Core.Tests
 
             //Assert
             //Assert.AreEqual(200, response.Object.StatusCode);
-            Assert.AreEqual(responseContent, featureSwitcheTypesJson);
+            //Assert.AreEqual(responseContent, featureSwitcheTypesJson);
 
         }
     }

--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -46,7 +46,7 @@ namespace Femah.Core.Tests
             Assert.AreEqual(Encoding.UTF8, response.Object.ContentEncoding);
         }
 
-        [Test] 
+        [Test]
         public void ApiResponseReturns500IfCollectionInvalid()
         {
             //Arrange
@@ -68,153 +68,146 @@ namespace Femah.Core.Tests
         public void ApiGetResponseReturns200IfCollectionValid()
         {
             //Arrange
-                var testable = new TestableFemahApiHttpHandler();
-                
-                var httpContextMock = new Mock<HttpContextBase>();
-                httpContextMock.Setup(x => x.Request.Url)
-                    .Returns(new Uri("http://example.com/femah.axd/api/featureswitches"));
-                httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("GET");
+            var testable = new TestableFemahApiHttpHandler();
 
-                var response = new Mock<HttpResponseBase>();
-                response.SetupProperty(x => x.StatusCode);
-                httpContextMock.Setup(x => x.Response).Returns(response.Object);
+            var httpContextMock = new Mock<HttpContextBase>();
+            httpContextMock.Setup(x => x.Request.Url)
+                .Returns(new Uri("http://example.com/femah.axd/api/featureswitches"));
+            httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("GET");
 
-                var featureSwitches = new List<IFeatureSwitch>
+            var response = new Mock<HttpResponseBase>();
+            response.SetupProperty(x => x.StatusCode);
+            httpContextMock.Setup(x => x.Response).Returns(response.Object);
+
+            var featureSwitches = new List<IFeatureSwitch>
+            {
+                (new SimpleFeatureSwitch
                 {
-                    (new SimpleFeatureSwitch
-                    {
-                        Name = "TestFeatureSwitch",
-                        IsEnabled = false,
-                        FeatureType = "SimpleFeatureSwitch"
-                    })
-                };
+                    Name = "TestFeatureSwitch",
+                    IsEnabled = false,
+                    FeatureType = "SimpleFeatureSwitch"
+                })
+            };
 
-                var providerMock = new Mock<IFeatureSwitchProvider>();
-                providerMock.Setup(p => p.All())
-                    .Returns(featureSwitches);
+            var providerMock = new Mock<IFeatureSwitchProvider>();
+            providerMock.Setup(p => p.AllFeatureSwitches())
+                .Returns(featureSwitches);
 
-                Femah.Configure()
-                    .FeatureSwitchEnum(typeof(FeatureSwitches))
-                    .Provider(providerMock.Object)
-                    .Initialise();
-            
-                //Get the JSON response by intercepting the call to context.Response.Write
-                string responseContent = string.Empty;
-                response.Setup(x => x.Write(It.IsAny<string>())).Callback((string r) => { responseContent = r; });
+            Femah.Configure()
+                .FeatureSwitchEnum(typeof (FeatureSwitches))
+                .Provider(providerMock.Object)
+                .Initialise();
+
+            //Get the JSON response by intercepting the call to context.Response.Write
+            string responseContent = string.Empty;
+            response.Setup(x => x.Write(It.IsAny<string>())).Callback((string r) => { responseContent = r; });
 
             //Act
-                testable.ProcessRequest(httpContextMock.Object);
+            testable.ProcessRequest(httpContextMock.Object);
 
             //Assert
-                Assert.AreEqual(200, response.Object.StatusCode);
+            Assert.AreEqual(200, response.Object.StatusCode);
         }
 
         [Test]
         public void ApiGetResponseReturnsValidCollectionOfFeatureSwitches()
         {
             //Arrange
-                var testable = new TestableFemahApiHttpHandler();
+            var testable = new TestableFemahApiHttpHandler();
 
-                var httpContextMock = new Mock<HttpContextBase>();
-                httpContextMock.Setup(x => x.Request.Url)
-                    .Returns(new Uri("http://example.com/femah.axd/api/featureswitches"));
-                httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("GET");
+            var httpContextMock = new Mock<HttpContextBase>();
+            httpContextMock.Setup(x => x.Request.Url)
+                .Returns(new Uri("http://example.com/femah.axd/api/featureswitches"));
+            httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("GET");
 
-                var response = new Mock<HttpResponseBase>();
-                response.SetupProperty(x => x.StatusCode);
-                httpContextMock.Setup(x => x.Response).Returns(response.Object);
+            var response = new Mock<HttpResponseBase>();
+            response.SetupProperty(x => x.StatusCode);
+            httpContextMock.Setup(x => x.Response).Returns(response.Object);
 
-                var featureSwitches = new List<IFeatureSwitch>
-                    {
-                        (new SimpleFeatureSwitch
-                        {
-                            Name = "TestFeatureSwitch1",
-                            IsEnabled = false,
-                            FeatureType = "SimpleFeatureSwitch"
-                        }),
-                        (new SimpleFeatureSwitch
-                        {
-                            Name = "TestFeatureSwitch2",
-                            IsEnabled = false,
-                            FeatureType = "SimpleFeatureSwitch"
-                        })
-                    };
+            var featureSwitches = new List<IFeatureSwitch>
+            {
+                (new SimpleFeatureSwitch
+                {
+                    Name = "TestFeatureSwitch1",
+                    IsEnabled = false,
+                    FeatureType = "SimpleFeatureSwitch"
+                }),
+                (new SimpleFeatureSwitch
+                {
+                    Name = "TestFeatureSwitch2",
+                    IsEnabled = false,
+                    FeatureType = "SimpleFeatureSwitch"
+                })
+            };
 
-                //Serialise for comparing what we get back from the API
-                //using our extension method
-                var featureSwitchesJson = featureSwitches.ToJson();
-                //or directly with JSON.NET?
-                //var featureSwitchesJson = JsonConvert.SerializeObject(featureSwitches);
+            //Serialise for comparing what we get back from the API
+            //using our extension method
+            var featureSwitchesJson = featureSwitches.ToJson();
+            //or directly with JSON.NET?
+            //var featureSwitchesJson = JsonConvert.SerializeObject(featureSwitches);
 
-                var providerMock = new Mock<IFeatureSwitchProvider>();
-                providerMock.Setup(p => p.All())
-                    .Returns(featureSwitches);
+            var providerMock = new Mock<IFeatureSwitchProvider>();
+            providerMock.Setup(p => p.AllFeatureSwitches())
+                .Returns(featureSwitches);
 
-                Femah.Configure()
-                    .FeatureSwitchEnum(typeof(FeatureSwitches))
-                    .Provider(providerMock.Object)
-                    .Initialise();
+            Femah.Configure()
+                .FeatureSwitchEnum(typeof (FeatureSwitches))
+                .Provider(providerMock.Object)
+                .Initialise();
 
-                //Get the JSON response by intercepting the call to context.Response.Write
-                string responseContent = string.Empty;
-                response.Setup(x => x.Write(It.IsAny<string>())).Callback((string r) => { responseContent = r; });
+            //Get the JSON response by intercepting the call to context.Response.Write
+            string responseContent = string.Empty;
+            response.Setup(x => x.Write(It.IsAny<string>())).Callback((string r) => { responseContent = r; });
 
             //Act
-                testable.ProcessRequest(httpContextMock.Object);
+            testable.ProcessRequest(httpContextMock.Object);
 
             //Asert
-                Assert.AreEqual(responseContent, featureSwitchesJson);
+            Assert.AreEqual(responseContent, featureSwitchesJson);
 
         }
 
-        //[Test]
-//        public void ApiGetResponseReturns200AndValidCollectionOfFeatureSwitchTypes()
-//        {
-//            //Arrange
-//            var testable = new TestableFemahApiHttpHandler();
-//            var context = new Mock<HttpContextBase>();
-//            context.Setup(x => x.Request.Url)
-//                .Returns(new Uri("http://example.com/femah.axd/api/featureswitchtypes"));
-//            context.SetupGet(x => x.Request.HttpMethod).Returns("GET");
-//
-//            var response = new Mock<HttpResponseBase>();
-//            response.SetupProperty(x => x.StatusCode);
-//            response.SetupProperty(x => x.Output);
-//            context.Setup(x => x.Response).Returns(response.Object);
-//
-//            var providerMock = new Mock<IFeatureSwitchProvider>();
-//            Femah.Configure()
-//                .Provider(providerMock.Object)
-//                .FeatureSwitchEnum(typeof(FemahTests.FeatureSwitches))
-//                .Initialise();
-//
-//            //Get the SwitchTypes directly from the Femah service and convert them to JSON using our friend JSON.NET 
-//            //var switchTypes = Femah.AllSwitchTypes();
-//            //var serialisedSwitchTypes = JsonConvert.SerializeObject(switchTypes);
-//
-//            //Get the JSON response by intercepting the call to context.Response.Write
-//            string responseContent = string.Empty;
-//            response.Setup(x => x.Write(It.IsAny<string>())).Callback((string r) => { responseContent = r; });
-//
-//            //Act
-//            testable.ProcessRequest(context.Object);
-//
-//
-//            //Assert
-//            Assert.AreEqual(200, response.Object.StatusCode);
-//
-//            JsonSchema schema = JsonSchema.Parse(@"{
-//                      'type': 'object',
-//                      'properties': {
-//                        'name': {'type':'string'},
-//                        'hobbies': {'type': 'array'}
-//                      }
-//                    }");
-//
-//            JObject featureswitches = JObject.Parse(responseContent);
-//
-//            bool valid = featureswitches.IsValid(schema);
-//            Assert.IsTrue(valid);
-//        }
+        [Test]
+        public void ApiGetResponseReturnsValidCollectionOfFeatureSwitchTypes()
+        {
+            //Arrange
+            var testable = new TestableFemahApiHttpHandler();
+            var httpContextMock = new Mock<HttpContextBase>();
+            httpContextMock.Setup(x => x.Request.Url)
+                .Returns(new Uri("http://example.com/femah.axd/api/featureswitchtypes"));
+            httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("GET");
+
+            var response = new Mock<HttpResponseBase>();
+            response.SetupProperty(x => x.StatusCode);
+            httpContextMock.Setup(x => x.Response).Returns(response.Object);
+
+            var featureSwitchTypes = new List<Type> {typeof (SimpleFeatureSwitch)};
+
+            //Serialise for comparing what we get back from the API
+            //using our extension method
+            var featureSwitcheTypesJson = featureSwitchTypes.ToJson();
+            //or directly with JSON.NET?
+            //var featureSwitchesJson = JsonConvert.SerializeObject(featureSwitches);
+
+            var providerMock = new Mock<IFeatureSwitchProvider>();
+            providerMock.Setup(p => p.AllFeatureSwitchTypes())
+                .Returns(featureSwitchTypes);
+
+            Femah.Configure()
+                .Provider(providerMock.Object)
+                .Initialise();
+
+            //Get the JSON response by intercepting the call to context.Response.Write
+            string responseContent = string.Empty;
+            response.Setup(x => x.Write(It.IsAny<string>())).Callback((string r) => { responseContent = r; });
+
+            //Act
+            testable.ProcessRequest(httpContextMock.Object);
+
+            //Assert
+            //Assert.AreEqual(200, response.Object.StatusCode);
+            Assert.AreEqual(responseContent, featureSwitcheTypesJson);
+
+        }
     }
 }

--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -142,7 +142,7 @@ namespace Femah.Core.Tests
 
                 //Serialise for comparing what we get back from the API
                 //using our extension method
-                //var featureSwitchesJson = featureSwitches.ToJson();
+                var featureSwitchesJson = featureSwitches.ToJson();
                 //or directly with JSON.NET?
                 //var featureSwitchesJson = JsonConvert.SerializeObject(featureSwitches);
 
@@ -163,10 +163,7 @@ namespace Femah.Core.Tests
                 testable.ProcessRequest(httpContextMock.Object);
 
             //Asert
-                //var deserialisedFeatureSwitches = JsonConvert.DeserializeObject <List<FeatureSwitchBase>>(responseContent);
-                //var deserialisedFeatureSwitches = JsonConvert.DeserializeObject(responseContent, typeof(List<FeatureSwitchBase>), new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Objects });
-                var deserialisedFeatureSwitches = (List<SimpleFeatureSwitch>)JsonConvert.DeserializeObject(responseContent, typeof(List<SimpleFeatureSwitch>));
-                Assert.AreEqual(featureSwitches, deserialisedFeatureSwitches);
+                Assert.AreEqual(responseContent, featureSwitchesJson);
 
         }
 

--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -142,7 +142,7 @@ namespace Femah.Core.Tests
 
                 //Serialise for comparing what we get back from the API
                 //using our extension method
-                var featureSwitchesJson = featureSwitches.ToJson();
+                //var featureSwitchesJson = featureSwitches.ToJson();
                 //or directly with JSON.NET?
                 //var featureSwitchesJson = JsonConvert.SerializeObject(featureSwitches);
 
@@ -163,7 +163,10 @@ namespace Femah.Core.Tests
                 testable.ProcessRequest(httpContextMock.Object);
 
             //Asert
-                Assert.AreEqual(responseContent, featureSwitchesJson);
+                //var deserialisedFeatureSwitches = JsonConvert.DeserializeObject <List<FeatureSwitchBase>>(responseContent);
+                //var deserialisedFeatureSwitches = JsonConvert.DeserializeObject(responseContent, typeof(List<FeatureSwitchBase>), new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Objects });
+                var deserialisedFeatureSwitches = (List<SimpleFeatureSwitch>)JsonConvert.DeserializeObject(responseContent, typeof(List<SimpleFeatureSwitch>));
+                Assert.AreEqual(featureSwitches, deserialisedFeatureSwitches);
 
         }
 

--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -181,20 +181,15 @@ namespace Femah.Core.Tests
             response.SetupProperty(x => x.StatusCode);
             httpContextMock.Setup(x => x.Response).Returns(response.Object);
 
-            var featureSwitchTypes = new List<Type> {typeof (SimpleFeatureSwitch)};
+            const int numberOfSwitchTypes = 1;
+            var featureSwitchTypes = new Type[numberOfSwitchTypes];
+            featureSwitchTypes[0] = typeof (SimpleFeatureSwitch);
 
             //Serialise for comparing what we get back from the API
-            //using our extension method
-            var featureSwitcheTypesJson = featureSwitchTypes.ToJson();
-            //or directly with JSON.NET?
-            //var featureSwitchesJson = JsonConvert.SerializeObject(featureSwitches);
-
-            var providerMock = new Mock<IFeatureSwitchProvider>();
-            //providerMock.Setup(p => p.AllFeatureSwitchTypes())
-            //    .Returns(featureSwitchTypes);
+            var featureSwitchTypesJson = featureSwitchTypes.ToJson();
 
             Femah.Configure()
-                .Provider(providerMock.Object)
+                .WithSelectedFeatureSwitchTypes(featureSwitchTypes)
                 .Initialise();
 
             //Get the JSON response by intercepting the call to context.Response.Write
@@ -205,8 +200,8 @@ namespace Femah.Core.Tests
             testable.ProcessRequest(httpContextMock.Object);
 
             //Assert
-            //Assert.AreEqual(200, response.Object.StatusCode);
-            //Assert.AreEqual(responseContent, featureSwitcheTypesJson);
+            Assert.AreEqual(200, response.Object.StatusCode);
+            Assert.AreEqual(featureSwitchTypesJson, responseContent);
 
         }
     }

--- a/Femah.Core/Configuration/FemahConfiguration.cs
+++ b/Femah.Core/Configuration/FemahConfiguration.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Femah.Core
+namespace Femah.Core.Configuration
 {
     public class FluentAssemblyConfiguration : FemahFluentConfiguration
     {
@@ -31,10 +28,12 @@ namespace Femah.Core
         public FemahConfiguration()
         {
             CustomSwitchTypes = new List<Type>();
+            StandardSwitchTypes = new List<Type>();
         }
 
         public IFemahContextFactory ContextFactory { get; set; }
         public IFeatureSwitchProvider Provider { get; set; }
+        public List<Type> StandardSwitchTypes { get; set; }
         public List<Type> CustomSwitchTypes { get; set; }
         public Type FeatureSwitchEnumType { get; set; }
     }

--- a/Femah.Core/Configuration/FemahFluentConfiguration.cs
+++ b/Femah.Core/Configuration/FemahFluentConfiguration.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Femah.Core
+namespace Femah.Core.Configuration
 {
     public class FemahFluentConfiguration
     {
@@ -23,7 +20,13 @@ namespace Femah.Core
             return this;
         }
 
-        public FemahFluentConfiguration AdditionalSwitchTypesFromAssembly(Assembly assembly)
+        /// <summary>
+        /// Provides the ability to configure femah with additional FeatureSwitchTypes from a given assembly. Used when 
+        /// extending femah with custom FeatureSwitchTypes residing in a non-femah assembly.
+        /// </summary>
+        /// <param name="assembly">The target assembly to configure custom FeatureSwitchTypes from</param>
+        /// <returns type="FemahFluentConfiguration" />
+        public FemahFluentConfiguration AdditionalFeatureSwitchTypesFromAssembly(Assembly assembly)
         {
             // Get all feature switch types from the assembly.
             var types = assembly.GetExportedTypes();
@@ -33,6 +36,22 @@ namespace Femah.Core
                 {
                     _config.CustomSwitchTypes.Add(t);
                 }
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Provides the ability to pass in and configure femah with a predefined collection of FeatureSwitchTypes, i.e. those 
+        /// types implementing IFeatureSwitch.  Predominantly used for unit testing purposes, allowing us to configure femah with
+        /// a known subset of FeatureSwitchTypes.
+        /// </summary>
+        /// <param name="types" type="Type[]">An array containing the FeatureSwitchTypes to configure</param>
+        /// <returns type="FemahFluentConfiguration" />
+        public FemahFluentConfiguration WithSelectedFeatureSwitchTypes(Type[] types)
+        {
+            foreach (var t in types.Where(t => t.GetInterfaces().Contains(typeof(IFeatureSwitch))))
+            {
+                _config.StandardSwitchTypes.Add(t);
             }
             return this;
         }

--- a/Femah.Core/Femah.cs
+++ b/Femah.Core/Femah.cs
@@ -40,7 +40,7 @@ namespace Femah.Core
             _switches = Femah.LoadFeatureSwitchList(config.FeatureSwitchEnumType, Assembly.GetCallingAssembly());
 
             // Inialise the provider.
-            _provider.Initialise(_switches.Values.ToList());
+            _provider.Initialise(_switches.Values.ToList(), _switchTypes);
 
             _initialised = true;
 
@@ -152,7 +152,7 @@ namespace Femah.Core
         /// <returns></returns>
         internal static List<IFeatureSwitch> AllFeatures()
         {
-            return _provider.All();
+            return _provider.AllFeatureSwitches();
         }
 
         /// <summary>
@@ -161,7 +161,8 @@ namespace Femah.Core
         /// <returns></returns>
         internal static List<Type> AllSwitchTypes()
         {
-            return _switchTypes;
+            //return _switchTypes;
+            return _provider.AllFeatureSwitchTypes();
         }
 
         /// <summary>

--- a/Femah.Core/Femah.cs
+++ b/Femah.Core/Femah.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using System.Reflection;
+using Femah.Core.Configuration;
 using Femah.Core.Providers;
 
 namespace Femah.Core
@@ -34,7 +35,13 @@ namespace Femah.Core
             // Save provider.
             _provider = config.Provider ?? new InProcProvider();
 
-            _switchTypes = Femah.LoadFeatureSwitchTypesFromAssembly(Assembly.GetExecutingAssembly());
+            if (config.StandardSwitchTypes.Count == 0)
+                _switchTypes = LoadFeatureSwitchTypesFromAssembly(Assembly.GetExecutingAssembly());
+            else
+            {
+                _switchTypes = new List<Type>();
+                _switchTypes.AddRange(config.StandardSwitchTypes);
+            }
             _switchTypes.AddRange(config.CustomSwitchTypes);
 
             _switches = Femah.LoadFeatureSwitchList(config.FeatureSwitchEnumType, Assembly.GetCallingAssembly());

--- a/Femah.Core/Femah.cs
+++ b/Femah.Core/Femah.cs
@@ -40,7 +40,7 @@ namespace Femah.Core
             _switches = Femah.LoadFeatureSwitchList(config.FeatureSwitchEnumType, Assembly.GetCallingAssembly());
 
             // Inialise the provider.
-            _provider.Initialise(_switches.Values.ToList(), _switchTypes);
+            _provider.Initialise(_switches.Values.ToList());
 
             _initialised = true;
 
@@ -161,8 +161,7 @@ namespace Femah.Core
         /// <returns></returns>
         internal static List<Type> AllSwitchTypes()
         {
-            //return _switchTypes;
-            return _provider.AllFeatureSwitchTypes();
+            return _switchTypes;
         }
 
         /// <summary>

--- a/Femah.Core/IFeatureSwitchProvider.cs
+++ b/Femah.Core/IFeatureSwitchProvider.cs
@@ -12,8 +12,7 @@ namespace Femah.Core
         /// Initialise the provider, given the names of the feature switches.
         /// </summary>
         /// <param name="featureSwitches">Names of the feature switches in the application.</param>
-        /// <param name="featureSwitchTypes">The feature switch types in the application.</param>
-        void Initialise(IEnumerable<string> featureSwitches, List<Type> featureSwitchTypes );
+        void Initialise(IEnumerable<string> featureSwitches);
 
         /// <summary>
         /// Get a feature switch.
@@ -34,6 +33,5 @@ namespace Femah.Core
         /// <returns>A list of zero or more instances of IFeatureSwitch</returns>
         List<IFeatureSwitch> AllFeatureSwitches();
 
-        List<Type> AllFeatureSwitchTypes();
     }
 }

--- a/Femah.Core/IFeatureSwitchProvider.cs
+++ b/Femah.Core/IFeatureSwitchProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Femah.Core
 {
@@ -11,7 +12,8 @@ namespace Femah.Core
         /// Initialise the provider, given the names of the feature switches.
         /// </summary>
         /// <param name="featureSwitches">Names of the feature switches in the application.</param>
-        void Initialise(IEnumerable<string> featureSwitches);
+        /// <param name="featureSwitchTypes">The feature switch types in the application.</param>
+        void Initialise(IEnumerable<string> featureSwitches, List<Type> featureSwitchTypes );
 
         /// <summary>
         /// Get a feature switch.
@@ -30,6 +32,8 @@ namespace Femah.Core
         /// Return all feature switches.
         /// </summary>
         /// <returns>A list of zero or more instances of IFeatureSwitch</returns>
-        List<IFeatureSwitch> All();
+        List<IFeatureSwitch> AllFeatureSwitches();
+
+        List<Type> AllFeatureSwitchTypes();
     }
 }

--- a/Femah.Core/Providers/InProcProvider.cs
+++ b/Femah.Core/Providers/InProcProvider.cs
@@ -17,8 +17,7 @@ namespace Femah.Core.Providers
         /// Initialise the feature switches in the provider.
         /// </summary>
         /// <param name="featureSwitches"></param>
-        /// <param name="featureSwitchTypes">The feature switch types in the application.</param>
-        public void Initialise( IEnumerable<string> featureSwitches, List<Type> featureSwitchTypes )
+        public void Initialise( IEnumerable<string> featureSwitches)
         {
             _featureSwitches.Clear();
 
@@ -26,9 +25,6 @@ namespace Femah.Core.Providers
             {
                 _featureSwitches.Add(new SimpleFeatureSwitch { Name = featureSwitch, IsEnabled = false, FeatureType = featureSwitch.GetType().Name});
             }
-
-            _featureSwitchtypes = featureSwitchTypes;
-
         }
 
         /// <summary>

--- a/Femah.Core/Providers/InProcProvider.cs
+++ b/Femah.Core/Providers/InProcProvider.cs
@@ -11,12 +11,14 @@ namespace Femah.Core.Providers
     public class InProcProvider : IFeatureSwitchProvider
     {
         static List<IFeatureSwitch> _featureSwitches = new List<IFeatureSwitch>();
+        static List<Type> _featureSwitchtypes = null;
 
         /// <summary>
         /// Initialise the feature switches in the provider.
         /// </summary>
         /// <param name="featureSwitches"></param>
-        public void Initialise( IEnumerable<string> featureSwitches )
+        /// <param name="featureSwitchTypes">The feature switch types in the application.</param>
+        public void Initialise( IEnumerable<string> featureSwitches, List<Type> featureSwitchTypes )
         {
             _featureSwitches.Clear();
 
@@ -24,6 +26,9 @@ namespace Femah.Core.Providers
             {
                 _featureSwitches.Add(new SimpleFeatureSwitch { Name = featureSwitch, IsEnabled = false, FeatureType = featureSwitch.GetType().Name});
             }
+
+            _featureSwitchtypes = featureSwitchTypes;
+
         }
 
         /// <summary>
@@ -55,9 +60,14 @@ namespace Femah.Core.Providers
         /// Return all feature switches in the provider.
         /// </summary>
         /// <returns></returns>
-        public List<IFeatureSwitch> All()
+        public List<IFeatureSwitch> AllFeatureSwitches()
         {
             return _featureSwitches;
+        }
+
+        public List<Type> AllFeatureSwitchTypes()
+        {
+            return _featureSwitchtypes;
         }
     }
 }

--- a/Femah.Core/Providers/SqlServerProvider.cs
+++ b/Femah.Core/Providers/SqlServerProvider.cs
@@ -54,8 +54,7 @@ namespace Femah.Core.Providers
         /// Initialise the provider, given the names of the feature switches.
         /// </summary>
         /// <param name="featureSwitches">Names of the feature switches in the application.</param>
-        /// <param name="featureSwitchTypes">The feature switch types in the application.</param>
-        public void Initialise(IEnumerable<string> featureSwitches, List<Type> featureSwitchTypes)
+        public void Initialise(IEnumerable<string> featureSwitches)
         {
             using (var conn = new SqlConnection(_connectionString))
             {
@@ -75,9 +74,6 @@ namespace Femah.Core.Providers
                 // Remove any feature switches from database that aren't valid feature switches.
                 DeleteUnlistedSwitches(featureSwitches, conn);
             }
-
-            _featureSwitchtypes.Clear();
-            _featureSwitchtypes = featureSwitchTypes;
         }
 
 

--- a/Femah.Core/Providers/SqlServerProvider.cs
+++ b/Femah.Core/Providers/SqlServerProvider.cs
@@ -37,7 +37,7 @@ namespace Femah.Core.Providers
     {
         private string _connectionString;
         private string _tableName = "femahSwitches";
-
+        static List<Type> _featureSwitchtypes = null;
 
         /// <summary>
         /// Configure the SqlServerProvider.
@@ -54,7 +54,8 @@ namespace Femah.Core.Providers
         /// Initialise the provider, given the names of the feature switches.
         /// </summary>
         /// <param name="featureSwitches">Names of the feature switches in the application.</param>
-        public void Initialise(IEnumerable<string> featureSwitches)
+        /// <param name="featureSwitchTypes">The feature switch types in the application.</param>
+        public void Initialise(IEnumerable<string> featureSwitches, List<Type> featureSwitchTypes)
         {
             using (var conn = new SqlConnection(_connectionString))
             {
@@ -74,7 +75,11 @@ namespace Femah.Core.Providers
                 // Remove any feature switches from database that aren't valid feature switches.
                 DeleteUnlistedSwitches(featureSwitches, conn);
             }
+
+            _featureSwitchtypes.Clear();
+            _featureSwitchtypes = featureSwitchTypes;
         }
+
 
         /// <summary>
         /// Get a feature switch.
@@ -111,7 +116,7 @@ namespace Femah.Core.Providers
         /// Return all feature switches.
         /// </summary>
         /// <returns>A list of zero or more instances of IFeatureSwitch</returns>
-        public List<IFeatureSwitch> All()
+        public List<IFeatureSwitch> AllFeatureSwitches()
         {
             List<IFeatureSwitch> featureSwitches;
 
@@ -122,6 +127,11 @@ namespace Femah.Core.Providers
             }
 
             return featureSwitches;
+        }
+
+        public List<Type> AllFeatureSwitchTypes()
+        {
+            return _featureSwitchtypes;
         }
 
         #endregion

--- a/TestResult.xml
+++ b/TestResult.xml
@@ -1,39 +1,51 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--This file represents the results of running a test suite-->
-<test-results name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" total="13" errors="0" failures="0" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2014-01-14" time="12:58:34">
+<test-results name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" total="21" errors="0" failures="0" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2014-02-10" time="17:13:58">
   <environment nunit-version="2.6.3.13283" clr-version="2.0.50727.7905" os-version="Microsoft Windows NT 6.2.9200.0" platform="Win32NT" cwd="C:\Development\GitHub\femah" machine-name="R9-FV2Z5-VM1" user="LHolman1" user-domain="HITACHICC" />
   <culture-info current-culture="en-GB" current-uiculture="en-GB" />
-  <test-suite type="Assembly" name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" executed="True" result="Success" success="True" time="1.238" asserts="0">
+  <test-suite type="Assembly" name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" executed="True" result="Success" success="True" time="1.944" asserts="0">
     <results>
-      <test-suite type="Namespace" name="Femah" executed="True" result="Success" success="True" time="1.215" asserts="0">
+      <test-suite type="Namespace" name="Femah" executed="True" result="Success" success="True" time="1.919" asserts="0">
         <results>
-          <test-suite type="Namespace" name="Core" executed="True" result="Success" success="True" time="1.212" asserts="0">
+          <test-suite type="Namespace" name="Core" executed="True" result="Success" success="True" time="1.916" asserts="0">
             <results>
-              <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.209" asserts="0">
+              <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.913" asserts="0">
                 <results>
-                  <test-suite type="TestFixture" name="FemahTests" executed="True" result="Success" success="True" time="0.728" asserts="0">
+                  <test-suite type="TestFixture" name="FemahApiTests" executed="True" result="Success" success="True" time="1.491" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextAreSwallowed" executed="True" result="Success" success="True" time="0.623" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextFactoryAreSwallowed" executed="True" result="Success" success="True" time="0.003" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByFeatureSwitchesAreSwallowed" executed="True" result="Success" success="True" time="0.025" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturns200IfCollectionValid" executed="True" result="Success" success="True" time="1.390" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturnsValidCollectionOfFeatureSwitches" executed="True" result="Success" success="True" time="0.018" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturnsValidCollectionOfFeatureSwitchTypes" executed="True" result="Success" success="True" time="0.031" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiResponseReturns500IfCollectionInvalid" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiResponseSetsCorrectContentTypeAndEncoding" executed="True" result="Success" success="True" time="0.014" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="FemahTests" executed="True" result="Success" success="True" time="0.225" asserts="0">
+                    <results>
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextAreSwallowed" executed="True" result="Success" success="True" time="0.016" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextFactoryAreSwallowed" executed="True" result="Success" success="True" time="0.004" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByFeatureSwitchesAreSwallowed" executed="True" result="Success" success="True" time="0.023" asserts="0" />
                       <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByProviderAreSwallowed" executed="True" result="Success" success="True" time="0.003" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithInvalidFeatureSwitchIdDoesntThrowException" executed="True" result="Success" success="True" time="0.041" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithoutInitialisingDoesntThrowException" executed="True" result="Success" success="True" time="0.007" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithInvalidFeatureSwitchIdDoesntThrowException" executed="True" result="Success" success="True" time="0.044" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithoutInitialisingDoesntThrowException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonMatchingDeserialisedType" executed="True" result="Success" success="True" time="0.111" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonWithExtraFieldNotPresentTargetType" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonWithMissingFieldFromTargetType" executed="True" result="Success" success="True" time="0.007" asserts="1" />
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="PercentageFeatureSwitchTests" executed="True" result="Success" success="True" time="0.426" asserts="0">
+                  <test-suite type="TestFixture" name="PercentageFeatureSwitchTests" executed="True" result="Success" success="True" time="0.145" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.IsOnIffRandomNumberBelowThreshold" executed="True" result="Success" success="True" time="0.358" asserts="0" />
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.SetsCookieWhenNoCookieExists" executed="True" result="Success" success="True" time="0.030" asserts="0" />
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.UsesValueFromCookieWhenCookieExists" executed="True" result="Success" success="True" time="0.034" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.IsOnIffRandomNumberBelowThreshold" executed="True" result="Success" success="True" time="0.086" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.SetsCookieWhenNoCookieExists" executed="True" result="Success" success="True" time="0.027" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.UsesValueFromCookieWhenCookieExists" executed="True" result="Success" success="True" time="0.028" asserts="0" />
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="RoleBasedFeatureSwitchTests" executed="True" result="Success" success="True" time="0.043" asserts="0">
+                  <test-suite type="TestFixture" name="RoleBasedFeatureSwitchTests" executed="True" result="Success" success="True" time="0.039" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenNoRoles" executed="True" result="Success" success="True" time="0.023" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenNoRoles" executed="True" result="Success" success="True" time="0.021" asserts="0" />
                       <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenUserNotInRole" executed="True" result="Success" success="True" time="0.005" asserts="0" />
                       <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInOneOfManyRoles" executed="True" result="Success" success="True" time="0.004" asserts="0" />
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInRole" executed="True" result="Success" success="True" time="0.005" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInRole" executed="True" result="Success" success="True" time="0.004" asserts="0" />
                     </results>
                   </test-suite>
                 </results>

--- a/TestResult.xml
+++ b/TestResult.xml
@@ -1,60 +1,51 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--This file represents the results of running a test suite-->
-<test-results name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" total="21" errors="0" failures="1" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2014-02-11" time="16:41:42">
+<test-results name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" total="21" errors="0" failures="0" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2014-02-11" time="17:42:11">
   <environment nunit-version="2.6.3.13283" clr-version="2.0.50727.7905" os-version="Microsoft Windows NT 6.2.9200.0" platform="Win32NT" cwd="C:\Development\GitHub\femah" machine-name="R9-FV2Z5-VM1" user="LHolman1" user-domain="HITACHICC" />
   <culture-info current-culture="en-GB" current-uiculture="en-GB" />
-  <test-suite type="Assembly" name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" executed="True" result="Failure" success="False" time="2.115" asserts="0">
+  <test-suite type="Assembly" name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" executed="True" result="Success" success="True" time="2.100" asserts="0">
     <results>
-      <test-suite type="Namespace" name="Femah" executed="True" result="Failure" success="False" time="2.088" asserts="0">
+      <test-suite type="Namespace" name="Femah" executed="True" result="Success" success="True" time="2.077" asserts="0">
         <results>
-          <test-suite type="Namespace" name="Core" executed="True" result="Failure" success="False" time="2.085" asserts="0">
+          <test-suite type="Namespace" name="Core" executed="True" result="Success" success="True" time="2.074" asserts="0">
             <results>
-              <test-suite type="Namespace" name="Tests" executed="True" result="Failure" success="False" time="2.080" asserts="0">
+              <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="2.071" asserts="0">
                 <results>
-                  <test-suite type="TestFixture" name="FemahApiTests" executed="True" result="Failure" success="False" time="1.631" asserts="0">
+                  <test-suite type="TestFixture" name="FemahApiTests" executed="True" result="Success" success="True" time="1.600" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturns200IfCollectionValid" executed="True" result="Success" success="True" time="1.482" asserts="1" />
-                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturnsValidCollectionOfFeatureSwitches" executed="True" result="Success" success="True" time="0.018" asserts="1" />
-                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturnsValidCollectionOfFeatureSwitchTypes" executed="True" result="Failure" success="False" time="0.064" asserts="1">
-                        <failure>
-                          <message><![CDATA[  Expected string length 365 but was 120. Strings differ at index 119.
-  Expected: "...=neutral, PublicKeyToken=null","Femah.Core.FeatureSwitchTy..."
-  But was:  "...=neutral, PublicKeyToken=null"]"
-  --------------------------------------------^
-]]></message>
-                          <stack-trace><![CDATA[]]></stack-trace>
-                        </failure>
-                      </test-case>
-                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiResponseReturns500IfCollectionInvalid" executed="True" result="Success" success="True" time="0.016" asserts="1" />
-                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiResponseSetsCorrectContentTypeAndEncoding" executed="True" result="Success" success="True" time="0.014" asserts="2" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturns200IfCollectionValid" executed="True" result="Success" success="True" time="1.475" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturnsValidCollectionOfFeatureSwitches" executed="True" result="Success" success="True" time="0.029" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturnsValidCollectionOfFeatureSwitchTypes" executed="True" result="Success" success="True" time="0.037" asserts="2" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiResponseReturns500IfCollectionInvalid" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiResponseSetsCorrectContentTypeAndEncoding" executed="True" result="Success" success="True" time="0.015" asserts="2" />
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="FemahTests" executed="True" result="Success" success="True" time="0.243" asserts="0">
+                  <test-suite type="TestFixture" name="FemahTests" executed="True" result="Success" success="True" time="0.237" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextAreSwallowed" executed="True" result="Success" success="True" time="0.017" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextAreSwallowed" executed="True" result="Success" success="True" time="0.016" asserts="0" />
                       <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextFactoryAreSwallowed" executed="True" result="Success" success="True" time="0.004" asserts="0" />
                       <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByFeatureSwitchesAreSwallowed" executed="True" result="Success" success="True" time="0.027" asserts="0" />
                       <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByProviderAreSwallowed" executed="True" result="Success" success="True" time="0.003" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithInvalidFeatureSwitchIdDoesntThrowException" executed="True" result="Success" success="True" time="0.042" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithoutInitialisingDoesntThrowException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonMatchingDeserialisedType" executed="True" result="Success" success="True" time="0.121" asserts="1" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonWithExtraFieldNotPresentTargetType" executed="True" result="Success" success="True" time="0.004" asserts="1" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonWithMissingFieldFromTargetType" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithInvalidFeatureSwitchIdDoesntThrowException" executed="True" result="Success" success="True" time="0.043" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithoutInitialisingDoesntThrowException" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonMatchingDeserialisedType" executed="True" result="Success" success="True" time="0.115" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonWithExtraFieldNotPresentTargetType" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonWithMissingFieldFromTargetType" executed="True" result="Success" success="True" time="0.008" asserts="1" />
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="PercentageFeatureSwitchTests" executed="True" result="Success" success="True" time="0.149" asserts="0">
+                  <test-suite type="TestFixture" name="PercentageFeatureSwitchTests" executed="True" result="Success" success="True" time="0.176" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.IsOnIffRandomNumberBelowThreshold" executed="True" result="Success" success="True" time="0.089" asserts="0" />
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.SetsCookieWhenNoCookieExists" executed="True" result="Success" success="True" time="0.026" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.IsOnIffRandomNumberBelowThreshold" executed="True" result="Success" success="True" time="0.110" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.SetsCookieWhenNoCookieExists" executed="True" result="Success" success="True" time="0.028" asserts="0" />
                       <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.UsesValueFromCookieWhenCookieExists" executed="True" result="Success" success="True" time="0.028" asserts="0" />
                     </results>
                   </test-suite>
                   <test-suite type="TestFixture" name="RoleBasedFeatureSwitchTests" executed="True" result="Success" success="True" time="0.045" asserts="0">
                     <results>
                       <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenNoRoles" executed="True" result="Success" success="True" time="0.023" asserts="0" />
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenUserNotInRole" executed="True" result="Success" success="True" time="0.005" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenUserNotInRole" executed="True" result="Success" success="True" time="0.006" asserts="0" />
                       <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInOneOfManyRoles" executed="True" result="Success" success="True" time="0.005" asserts="0" />
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInRole" executed="True" result="Success" success="True" time="0.005" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInRole" executed="True" result="Success" success="True" time="0.004" asserts="0" />
                     </results>
                   </test-suite>
                 </results>

--- a/TestResult.xml
+++ b/TestResult.xml
@@ -1,39 +1,59 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--This file represents the results of running a test suite-->
-<test-results name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" total="13" errors="0" failures="0" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2014-01-14" time="12:58:34">
+<test-results name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" total="20" errors="0" failures="1" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2014-02-05" time="22:23:54">
   <environment nunit-version="2.6.3.13283" clr-version="2.0.50727.7905" os-version="Microsoft Windows NT 6.2.9200.0" platform="Win32NT" cwd="C:\Development\GitHub\femah" machine-name="R9-FV2Z5-VM1" user="LHolman1" user-domain="HITACHICC" />
   <culture-info current-culture="en-GB" current-uiculture="en-GB" />
-  <test-suite type="Assembly" name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" executed="True" result="Success" success="True" time="1.238" asserts="0">
+  <test-suite type="Assembly" name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" executed="True" result="Failure" success="False" time="2.430" asserts="0">
     <results>
-      <test-suite type="Namespace" name="Femah" executed="True" result="Success" success="True" time="1.215" asserts="0">
+      <test-suite type="Namespace" name="Femah" executed="True" result="Failure" success="False" time="2.402" asserts="0">
         <results>
-          <test-suite type="Namespace" name="Core" executed="True" result="Success" success="True" time="1.212" asserts="0">
+          <test-suite type="Namespace" name="Core" executed="True" result="Failure" success="False" time="2.400" asserts="0">
             <results>
-              <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.209" asserts="0">
+              <test-suite type="Namespace" name="Tests" executed="True" result="Failure" success="False" time="2.396" asserts="0">
                 <results>
-                  <test-suite type="TestFixture" name="FemahTests" executed="True" result="Success" success="True" time="0.728" asserts="0">
+                  <test-suite type="TestFixture" name="FemahApiTests" executed="True" result="Failure" success="False" time="1.987" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextAreSwallowed" executed="True" result="Success" success="True" time="0.623" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextFactoryAreSwallowed" executed="True" result="Success" success="True" time="0.003" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByFeatureSwitchesAreSwallowed" executed="True" result="Success" success="True" time="0.025" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturns200IfCollectionValid" executed="True" result="Success" success="True" time="1.763" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturnsValidCollectionOfFeatureSwitches" executed="True" result="Failure" success="False" time="0.157" asserts="1">
+                        <failure>
+                          <message><![CDATA[  Expected is <System.Collections.Generic.List`1[Femah.Core.IFeatureSwitch]> with 2 elements, actual is <System.Collections.Generic.List`1[Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch]> with 2 elements
+  Values differ at index [0]
+  Expected: <Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch>
+  But was:  <Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch>
+]]></message>
+                          <stack-trace><![CDATA[]]></stack-trace>
+                        </failure>
+                      </test-case>
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiResponseReturns500IfCollectionInvalid" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiResponseSetsCorrectContentTypeAndEncoding" executed="True" result="Success" success="True" time="0.023" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="FemahTests" executed="True" result="Success" success="True" time="0.172" asserts="0">
+                    <results>
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextAreSwallowed" executed="True" result="Success" success="True" time="0.019" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextFactoryAreSwallowed" executed="True" result="Success" success="True" time="0.004" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByFeatureSwitchesAreSwallowed" executed="True" result="Success" success="True" time="0.026" asserts="0" />
                       <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByProviderAreSwallowed" executed="True" result="Success" success="True" time="0.003" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithInvalidFeatureSwitchIdDoesntThrowException" executed="True" result="Success" success="True" time="0.041" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithoutInitialisingDoesntThrowException" executed="True" result="Success" success="True" time="0.007" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithInvalidFeatureSwitchIdDoesntThrowException" executed="True" result="Success" success="True" time="0.065" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithoutInitialisingDoesntThrowException" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonMatchingDeserialisedType" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonWithExtraFieldNotPresentTargetType" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonWithMissingFieldFromTargetType" executed="True" result="Success" success="True" time="0.011" asserts="1" />
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="PercentageFeatureSwitchTests" executed="True" result="Success" success="True" time="0.426" asserts="0">
+                  <test-suite type="TestFixture" name="PercentageFeatureSwitchTests" executed="True" result="Success" success="True" time="0.174" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.IsOnIffRandomNumberBelowThreshold" executed="True" result="Success" success="True" time="0.358" asserts="0" />
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.SetsCookieWhenNoCookieExists" executed="True" result="Success" success="True" time="0.030" asserts="0" />
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.UsesValueFromCookieWhenCookieExists" executed="True" result="Success" success="True" time="0.034" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.IsOnIffRandomNumberBelowThreshold" executed="True" result="Success" success="True" time="0.096" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.SetsCookieWhenNoCookieExists" executed="True" result="Success" success="True" time="0.041" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.UsesValueFromCookieWhenCookieExists" executed="True" result="Success" success="True" time="0.030" asserts="0" />
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="RoleBasedFeatureSwitchTests" executed="True" result="Success" success="True" time="0.043" asserts="0">
+                  <test-suite type="TestFixture" name="RoleBasedFeatureSwitchTests" executed="True" result="Success" success="True" time="0.047" asserts="0">
                     <results>
                       <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenNoRoles" executed="True" result="Success" success="True" time="0.023" asserts="0" />
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenUserNotInRole" executed="True" result="Success" success="True" time="0.005" asserts="0" />
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInOneOfManyRoles" executed="True" result="Success" success="True" time="0.004" asserts="0" />
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInRole" executed="True" result="Success" success="True" time="0.005" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenUserNotInRole" executed="True" result="Success" success="True" time="0.006" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInOneOfManyRoles" executed="True" result="Success" success="True" time="0.005" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInRole" executed="True" result="Success" success="True" time="0.006" asserts="0" />
                     </results>
                   </test-suite>
                 </results>

--- a/TestResult.xml
+++ b/TestResult.xml
@@ -1,59 +1,39 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--This file represents the results of running a test suite-->
-<test-results name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" total="20" errors="0" failures="1" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2014-02-05" time="22:23:54">
+<test-results name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" total="13" errors="0" failures="0" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2014-01-14" time="12:58:34">
   <environment nunit-version="2.6.3.13283" clr-version="2.0.50727.7905" os-version="Microsoft Windows NT 6.2.9200.0" platform="Win32NT" cwd="C:\Development\GitHub\femah" machine-name="R9-FV2Z5-VM1" user="LHolman1" user-domain="HITACHICC" />
   <culture-info current-culture="en-GB" current-uiculture="en-GB" />
-  <test-suite type="Assembly" name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" executed="True" result="Failure" success="False" time="2.430" asserts="0">
+  <test-suite type="Assembly" name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" executed="True" result="Success" success="True" time="1.238" asserts="0">
     <results>
-      <test-suite type="Namespace" name="Femah" executed="True" result="Failure" success="False" time="2.402" asserts="0">
+      <test-suite type="Namespace" name="Femah" executed="True" result="Success" success="True" time="1.215" asserts="0">
         <results>
-          <test-suite type="Namespace" name="Core" executed="True" result="Failure" success="False" time="2.400" asserts="0">
+          <test-suite type="Namespace" name="Core" executed="True" result="Success" success="True" time="1.212" asserts="0">
             <results>
-              <test-suite type="Namespace" name="Tests" executed="True" result="Failure" success="False" time="2.396" asserts="0">
+              <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.209" asserts="0">
                 <results>
-                  <test-suite type="TestFixture" name="FemahApiTests" executed="True" result="Failure" success="False" time="1.987" asserts="0">
+                  <test-suite type="TestFixture" name="FemahTests" executed="True" result="Success" success="True" time="0.728" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturns200IfCollectionValid" executed="True" result="Success" success="True" time="1.763" asserts="1" />
-                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturnsValidCollectionOfFeatureSwitches" executed="True" result="Failure" success="False" time="0.157" asserts="1">
-                        <failure>
-                          <message><![CDATA[  Expected is <System.Collections.Generic.List`1[Femah.Core.IFeatureSwitch]> with 2 elements, actual is <System.Collections.Generic.List`1[Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch]> with 2 elements
-  Values differ at index [0]
-  Expected: <Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch>
-  But was:  <Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch>
-]]></message>
-                          <stack-trace><![CDATA[]]></stack-trace>
-                        </failure>
-                      </test-case>
-                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiResponseReturns500IfCollectionInvalid" executed="True" result="Success" success="True" time="0.010" asserts="1" />
-                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiResponseSetsCorrectContentTypeAndEncoding" executed="True" result="Success" success="True" time="0.023" asserts="2" />
-                    </results>
-                  </test-suite>
-                  <test-suite type="TestFixture" name="FemahTests" executed="True" result="Success" success="True" time="0.172" asserts="0">
-                    <results>
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextAreSwallowed" executed="True" result="Success" success="True" time="0.019" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextFactoryAreSwallowed" executed="True" result="Success" success="True" time="0.004" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByFeatureSwitchesAreSwallowed" executed="True" result="Success" success="True" time="0.026" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextAreSwallowed" executed="True" result="Success" success="True" time="0.623" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextFactoryAreSwallowed" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByFeatureSwitchesAreSwallowed" executed="True" result="Success" success="True" time="0.025" asserts="0" />
                       <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByProviderAreSwallowed" executed="True" result="Success" success="True" time="0.003" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithInvalidFeatureSwitchIdDoesntThrowException" executed="True" result="Success" success="True" time="0.065" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithoutInitialisingDoesntThrowException" executed="True" result="Success" success="True" time="0.002" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonMatchingDeserialisedType" executed="True" result="Success" success="True" time="0.011" asserts="1" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonWithExtraFieldNotPresentTargetType" executed="True" result="Success" success="True" time="0.005" asserts="1" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonWithMissingFieldFromTargetType" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithInvalidFeatureSwitchIdDoesntThrowException" executed="True" result="Success" success="True" time="0.041" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithoutInitialisingDoesntThrowException" executed="True" result="Success" success="True" time="0.007" asserts="0" />
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="PercentageFeatureSwitchTests" executed="True" result="Success" success="True" time="0.174" asserts="0">
+                  <test-suite type="TestFixture" name="PercentageFeatureSwitchTests" executed="True" result="Success" success="True" time="0.426" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.IsOnIffRandomNumberBelowThreshold" executed="True" result="Success" success="True" time="0.096" asserts="0" />
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.SetsCookieWhenNoCookieExists" executed="True" result="Success" success="True" time="0.041" asserts="0" />
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.UsesValueFromCookieWhenCookieExists" executed="True" result="Success" success="True" time="0.030" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.IsOnIffRandomNumberBelowThreshold" executed="True" result="Success" success="True" time="0.358" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.SetsCookieWhenNoCookieExists" executed="True" result="Success" success="True" time="0.030" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.UsesValueFromCookieWhenCookieExists" executed="True" result="Success" success="True" time="0.034" asserts="0" />
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="RoleBasedFeatureSwitchTests" executed="True" result="Success" success="True" time="0.047" asserts="0">
+                  <test-suite type="TestFixture" name="RoleBasedFeatureSwitchTests" executed="True" result="Success" success="True" time="0.043" asserts="0">
                     <results>
                       <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenNoRoles" executed="True" result="Success" success="True" time="0.023" asserts="0" />
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenUserNotInRole" executed="True" result="Success" success="True" time="0.006" asserts="0" />
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInOneOfManyRoles" executed="True" result="Success" success="True" time="0.005" asserts="0" />
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInRole" executed="True" result="Success" success="True" time="0.006" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenUserNotInRole" executed="True" result="Success" success="True" time="0.005" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInOneOfManyRoles" executed="True" result="Success" success="True" time="0.004" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInRole" executed="True" result="Success" success="True" time="0.005" asserts="0" />
                     </results>
                   </test-suite>
                 </results>

--- a/TestResult.xml
+++ b/TestResult.xml
@@ -1,51 +1,60 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--This file represents the results of running a test suite-->
-<test-results name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" total="21" errors="0" failures="0" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2014-02-10" time="17:13:58">
+<test-results name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" total="21" errors="0" failures="1" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2014-02-11" time="16:41:42">
   <environment nunit-version="2.6.3.13283" clr-version="2.0.50727.7905" os-version="Microsoft Windows NT 6.2.9200.0" platform="Win32NT" cwd="C:\Development\GitHub\femah" machine-name="R9-FV2Z5-VM1" user="LHolman1" user-domain="HITACHICC" />
   <culture-info current-culture="en-GB" current-uiculture="en-GB" />
-  <test-suite type="Assembly" name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" executed="True" result="Success" success="True" time="1.944" asserts="0">
+  <test-suite type="Assembly" name="C:\Development\GitHub\femah\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll" executed="True" result="Failure" success="False" time="2.115" asserts="0">
     <results>
-      <test-suite type="Namespace" name="Femah" executed="True" result="Success" success="True" time="1.919" asserts="0">
+      <test-suite type="Namespace" name="Femah" executed="True" result="Failure" success="False" time="2.088" asserts="0">
         <results>
-          <test-suite type="Namespace" name="Core" executed="True" result="Success" success="True" time="1.916" asserts="0">
+          <test-suite type="Namespace" name="Core" executed="True" result="Failure" success="False" time="2.085" asserts="0">
             <results>
-              <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.913" asserts="0">
+              <test-suite type="Namespace" name="Tests" executed="True" result="Failure" success="False" time="2.080" asserts="0">
                 <results>
-                  <test-suite type="TestFixture" name="FemahApiTests" executed="True" result="Success" success="True" time="1.491" asserts="0">
+                  <test-suite type="TestFixture" name="FemahApiTests" executed="True" result="Failure" success="False" time="1.631" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturns200IfCollectionValid" executed="True" result="Success" success="True" time="1.390" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturns200IfCollectionValid" executed="True" result="Success" success="True" time="1.482" asserts="1" />
                       <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturnsValidCollectionOfFeatureSwitches" executed="True" result="Success" success="True" time="0.018" asserts="1" />
-                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturnsValidCollectionOfFeatureSwitchTypes" executed="True" result="Success" success="True" time="0.031" asserts="1" />
-                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiResponseReturns500IfCollectionInvalid" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiGetResponseReturnsValidCollectionOfFeatureSwitchTypes" executed="True" result="Failure" success="False" time="0.064" asserts="1">
+                        <failure>
+                          <message><![CDATA[  Expected string length 365 but was 120. Strings differ at index 119.
+  Expected: "...=neutral, PublicKeyToken=null","Femah.Core.FeatureSwitchTy..."
+  But was:  "...=neutral, PublicKeyToken=null"]"
+  --------------------------------------------^
+]]></message>
+                          <stack-trace><![CDATA[]]></stack-trace>
+                        </failure>
+                      </test-case>
+                      <test-case name="Femah.Core.Tests.FemahApiTests.ApiResponseReturns500IfCollectionInvalid" executed="True" result="Success" success="True" time="0.016" asserts="1" />
                       <test-case name="Femah.Core.Tests.FemahApiTests.ApiResponseSetsCorrectContentTypeAndEncoding" executed="True" result="Success" success="True" time="0.014" asserts="2" />
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="FemahTests" executed="True" result="Success" success="True" time="0.225" asserts="0">
+                  <test-suite type="TestFixture" name="FemahTests" executed="True" result="Success" success="True" time="0.243" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextAreSwallowed" executed="True" result="Success" success="True" time="0.016" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextAreSwallowed" executed="True" result="Success" success="True" time="0.017" asserts="0" />
                       <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByContextFactoryAreSwallowed" executed="True" result="Success" success="True" time="0.004" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByFeatureSwitchesAreSwallowed" executed="True" result="Success" success="True" time="0.023" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByFeatureSwitchesAreSwallowed" executed="True" result="Success" success="True" time="0.027" asserts="0" />
                       <test-case name="Femah.Core.Tests.FemahTests.ExceptionsThrownByProviderAreSwallowed" executed="True" result="Success" success="True" time="0.003" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithInvalidFeatureSwitchIdDoesntThrowException" executed="True" result="Success" success="True" time="0.044" asserts="0" />
+                      <test-case name="Femah.Core.Tests.FemahTests.InvokingWithInvalidFeatureSwitchIdDoesntThrowException" executed="True" result="Success" success="True" time="0.042" asserts="0" />
                       <test-case name="Femah.Core.Tests.FemahTests.InvokingWithoutInitialisingDoesntThrowException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonMatchingDeserialisedType" executed="True" result="Success" success="True" time="0.111" asserts="1" />
-                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonWithExtraFieldNotPresentTargetType" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonMatchingDeserialisedType" executed="True" result="Success" success="True" time="0.121" asserts="1" />
+                      <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonWithExtraFieldNotPresentTargetType" executed="True" result="Success" success="True" time="0.004" asserts="1" />
                       <test-case name="Femah.Core.Tests.FemahTests.ReadsValidJsonWithMissingFieldFromTargetType" executed="True" result="Success" success="True" time="0.007" asserts="1" />
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="PercentageFeatureSwitchTests" executed="True" result="Success" success="True" time="0.145" asserts="0">
+                  <test-suite type="TestFixture" name="PercentageFeatureSwitchTests" executed="True" result="Success" success="True" time="0.149" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.IsOnIffRandomNumberBelowThreshold" executed="True" result="Success" success="True" time="0.086" asserts="0" />
-                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.SetsCookieWhenNoCookieExists" executed="True" result="Success" success="True" time="0.027" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.IsOnIffRandomNumberBelowThreshold" executed="True" result="Success" success="True" time="0.089" asserts="0" />
+                      <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.SetsCookieWhenNoCookieExists" executed="True" result="Success" success="True" time="0.026" asserts="0" />
                       <test-case name="Femah.Core.Tests.PercentageFeatureSwitchTests.UsesValueFromCookieWhenCookieExists" executed="True" result="Success" success="True" time="0.028" asserts="0" />
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="RoleBasedFeatureSwitchTests" executed="True" result="Success" success="True" time="0.039" asserts="0">
+                  <test-suite type="TestFixture" name="RoleBasedFeatureSwitchTests" executed="True" result="Success" success="True" time="0.045" asserts="0">
                     <results>
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenNoRoles" executed="True" result="Success" success="True" time="0.021" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenNoRoles" executed="True" result="Success" success="True" time="0.023" asserts="0" />
                       <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsFalseWhenUserNotInRole" executed="True" result="Success" success="True" time="0.005" asserts="0" />
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInOneOfManyRoles" executed="True" result="Success" success="True" time="0.004" asserts="0" />
-                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInRole" executed="True" result="Success" success="True" time="0.004" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInOneOfManyRoles" executed="True" result="Success" success="True" time="0.005" asserts="0" />
+                      <test-case name="Femah.Core.Tests.RoleBasedFeatureSwitchTests.ReturnsTrueWhenUserInRole" executed="True" result="Success" success="True" time="0.005" asserts="0" />
                     </results>
                   </test-suite>
                 </results>

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,8 @@
 #Femah#
 
+<a href="https://github.com/lloydstone/femah"><img src="https://f.cloud.github.com/assets/362197/2124054/b67ee748-9237-11e3-8b44-ff2bd7fba50c.png
+" alt="Femah project home logo"/></a>
+
 <a href="http://teamcity.jetbrains.com/viewType.html?buildTypeId=NetCommunityProjects_Femah_Femah&guest=1"><img src="http://teamcity.jetbrains.com/app/rest/builds/buildType:(id:NetCommunityProjects_Femah_Femah)/statusIcon" alt="teamcity.jetbrains Femah build status"/></a>
 
 ##Introduction##

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,5 @@
 #Femah#
 
-<a href="https://github.com/lloydstone/femah"><img src="https://f.cloud.github.com/assets/362197/2124054/b67ee748-9237-11e3-8b44-ff2bd7fba50c.png
-" alt="Femah project home logo"/></a>
-
 <a href="http://teamcity.jetbrains.com/viewType.html?buildTypeId=NetCommunityProjects_Femah_Femah&guest=1"><img src="http://teamcity.jetbrains.com/app/rest/builds/buildType:(id:NetCommunityProjects_Femah_Femah)/statusIcon" alt="teamcity.jetbrains Femah build status"/></a>
 
 ##Introduction##

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,6 @@
 #Femah#
 
-<a href="https://github.com/lloydstone/femah"><img src="https://f.cloud.github.com/assets/362197/2124054/b67ee748-9237-11e3-8b44-ff2bd7fba50c.png
-" alt="Femah project home logo"/></a>
+<a href="https://github.com/lloydstone/femah"><img src="https://f.cloud.github.com/assets/362197/2124054/b67ee748-9237-11e3-8b44-ff2bd7fba50c.png" alt="Femah project home logo"/></a>
 
 <a href="http://teamcity.jetbrains.com/viewType.html?buildTypeId=NetCommunityProjects_Femah_Femah&guest=1"><img src="http://teamcity.jetbrains.com/app/rest/builds/buildType:(id:NetCommunityProjects_Femah_Femah)/statusIcon" alt="teamcity.jetbrains Femah build status"/></a>
 


### PR DESCRIPTION
#24 - API integration to support Admin UI and basic use cases. Modified the previous botched attempt (see #32) and this time allowed testing of FeatureSwitchType retrieval (AllSwitchTypes) by providing the ability to pass in a subset of selected FeatureSwitchTypes to the FemahFluentConfiguration.
- Also added link to femah logo to readme
