### PR TITLE
#24 API integration to support Admin UI and basic use cases

### DIFF
--- a/Femah.Core.Tests/Femah.Core.Tests.csproj
+++ b/Femah.Core.Tests/Femah.Core.Tests.csproj
@@ -26,7 +26,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>BuildOutput\$(TargetFrameworkVersion)</OutputPath>
+    <OutputPath>BuildOutput\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Text;
 using System.Web;
 using Femah.Core.Api;
-using Femah.Core.ExtensionMethods;
 using Femah.Core.FeatureSwitchTypes;
 using Moq;
 using NUnit.Framework;
@@ -25,8 +24,10 @@ namespace Femah.Core.Tests
             SomeNewFeature = 1
         }
 
+        #region General API (GET methods)
+
         [Test]
-        public void ApiResponseSetsCorrectContentTypeAndEncoding()
+        public void ApiGetSetsCorrectContentTypeAndEncodingInResponse()
         {
             //Arrange
             var testable = new TestableFemahApiHttpHandler();
@@ -46,25 +47,7 @@ namespace Femah.Core.Tests
         }
 
         [Test]
-        public void ApiResponseReturns500IfCollectionInvalid()
-        {
-            //Arrange
-            var testable = new TestableFemahApiHttpHandler();
-            var context = new Mock<HttpContextBase>();
-            context.Setup(x => x.Request.Url)
-                .Returns(new Uri("http://example.com/femah.axd/api/unknowncollectionbla"));
-            var response = new Mock<HttpResponseBase>();
-            response.SetupProperty(x => x.StatusCode);
-            context.Setup(x => x.Response).Returns(response.Object);
-
-            //Act
-            testable.ProcessRequest(context.Object);
-
-            Assert.AreEqual(500, response.Object.StatusCode);
-        }
-
-        [Test]
-        public void ApiGetResponseReturns200IfCollectionValid()
+        public void ApiGetReturns200IfServiceExists()
         {
             //Arrange
             var testable = new TestableFemahApiHttpHandler();
@@ -93,7 +76,107 @@ namespace Femah.Core.Tests
                 .Returns(featureSwitches);
 
             Femah.Configure()
-                .FeatureSwitchEnum(typeof (FeatureSwitches))
+                .FeatureSwitchEnum(typeof(FeatureSwitches))
+                .Provider(providerMock.Object)
+                .Initialise();
+
+            //Act
+            testable.ProcessRequest(httpContextMock.Object);
+
+            //Assert
+            Assert.AreEqual(200, response.Object.StatusCode);
+        }
+
+        [Test]
+        public void ApiGetReturns404IfServiceNotFound()
+        {
+            //Arrange
+            var testable = new TestableFemahApiHttpHandler();
+            var httpContextMock = new Mock<HttpContextBase>();
+            httpContextMock.Setup(x => x.Request.Url)
+                .Returns(new Uri("http://example.com/femah.axd/api/unknownservicebla"));
+            httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("GET");
+
+            var response = new Mock<HttpResponseBase>();
+            response.SetupProperty(x => x.StatusCode);
+            httpContextMock.Setup(x => x.Response).Returns(response.Object);
+
+            //Act
+            testable.ProcessRequest(httpContextMock.Object);
+
+            Assert.AreEqual(404, response.Object.StatusCode);
+        }
+
+        [Test]
+        public void ApiGetReturns405AndAccurateErrorMessageIfServiceDoesNotSupportParameterQuerying()
+        {
+            //string.Format("Error: Service: '{0}' does not support parameter querying.", apiRequest.Service))
+            //Arrange
+            var testable = new TestableFemahApiHttpHandler();
+            var httpContextMock = new Mock<HttpContextBase>();
+            httpContextMock.Setup(x => x.Request.Url)
+                .Returns(new Uri("http://example.com/femah.axd/api/featureswitchtypes/simplefeatureswitch"));
+            httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("GET");
+
+            var response = new Mock<HttpResponseBase>();
+            response.SetupProperty(x => x.StatusCode);
+            httpContextMock.Setup(x => x.Response).Returns(response.Object);
+
+            const int numberOfSwitchTypes = 2;
+            var featureSwitchTypes = new Type[numberOfSwitchTypes];
+            featureSwitchTypes[0] = typeof(SimpleFeatureSwitch);
+            featureSwitchTypes[1] = typeof(SimpleFeatureSwitch);
+
+            const string expectedJsonResponse = "\"Error: Service 'featureswitchtypes' does not support parameter querying.\"";
+
+            Femah.Configure()
+                .WithSelectedFeatureSwitchTypes(featureSwitchTypes)
+                .Initialise();
+
+            //Get the JSON response by intercepting the call to context.Response.Write
+            string responseContent = string.Empty;
+            response.Setup(x => x.Write(It.IsAny<string>())).Callback((string r) => { responseContent = r; });
+
+            //Act
+            testable.ProcessRequest(httpContextMock.Object);
+
+            //Asert
+            Assert.AreEqual(405, response.Object.StatusCode);
+            Assert.AreEqual(expectedJsonResponse, responseContent);
+        }
+
+        [Test]
+        public void ApiGetReturns500AndAccurateErrorMessageIfRequestUrlIsInvalidAndContainsTooManySegments()
+        {
+            //apiRequest.ErrorMessage = string.Format("Error: The requested Url: '{0}' does not match the expected format /femah.axd/api/[service]/[parameter]", request.Url);
+            //Arrange
+            var testable = new TestableFemahApiHttpHandler();
+
+            var httpContextMock = new Mock<HttpContextBase>();
+            httpContextMock.Setup(x => x.Request.Url)
+                .Returns(new Uri("http://example.com/femah.axd/api/invalid/url/structure"));
+            httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("GET");
+
+            var response = new Mock<HttpResponseBase>();
+            response.SetupProperty(x => x.StatusCode);
+            httpContextMock.Setup(x => x.Response).Returns(response.Object);
+
+            var featureSwitch = new SimpleFeatureSwitch
+            {
+                Name = "TestFeatureSwitch1",
+                IsEnabled = false,
+                FeatureType = "SimpleFeatureSwitch"
+            };
+
+            const string expectedJsonResponse =
+                "\"Error: The requested Url 'http://example.com/femah.axd/api/invalid/url/structure' does not match the expected format /femah.axd/api/[service]/[parameter].\"";
+
+            var providerMock = new Mock<IFeatureSwitchProvider>();
+            providerMock.Setup(p => p.Get(featureSwitch.Name.ToLower()))
+                .Returns(featureSwitch);
+
+            Femah.Configure()
+                .FeatureSwitchEnum(typeof(FeatureSwitches))
                 .Provider(providerMock.Object)
                 .Initialise();
 
@@ -104,12 +187,63 @@ namespace Femah.Core.Tests
             //Act
             testable.ProcessRequest(httpContextMock.Object);
 
-            //Assert
-            Assert.AreEqual(200, response.Object.StatusCode);
+            //Asert
+            Assert.AreEqual(500, response.Object.StatusCode);
+            Assert.AreEqual(expectedJsonResponse, responseContent);
         }
 
         [Test]
-        public void ApiGetResponseReturnsValidCollectionOfFeatureSwitches()
+        public void ApiGetReturns500AndAccurateErrorMessageIfRequestUrlIsInvalidAndContainsTooFewSegments()
+        {
+            //Arrange
+            var testable = new TestableFemahApiHttpHandler();
+
+            var httpContextMock = new Mock<HttpContextBase>();
+            httpContextMock.Setup(x => x.Request.Url)
+                .Returns(new Uri("http://example.com/femah.axd/api"));
+            httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("GET");
+
+            var response = new Mock<HttpResponseBase>();
+            response.SetupProperty(x => x.StatusCode);
+            httpContextMock.Setup(x => x.Response).Returns(response.Object);
+
+            var featureSwitch = new SimpleFeatureSwitch
+            {
+                Name = "TestFeatureSwitch1",
+                IsEnabled = false,
+                FeatureType = "SimpleFeatureSwitch"
+            };
+
+            const string expectedJsonResponse =
+                "\"Error: The requested Url 'http://example.com/femah.axd/api' does not match the expected format /femah.axd/api/[service]/[parameter].\"";
+
+            var providerMock = new Mock<IFeatureSwitchProvider>();
+            providerMock.Setup(p => p.Get(featureSwitch.Name.ToLower()))
+                .Returns(featureSwitch);
+
+            Femah.Configure()
+                .FeatureSwitchEnum(typeof(FeatureSwitches))
+                .Provider(providerMock.Object)
+                .Initialise();
+
+            //Get the JSON response by intercepting the call to context.Response.Write
+            string responseContent = string.Empty;
+            response.Setup(x => x.Write(It.IsAny<string>())).Callback((string r) => { responseContent = r; });
+
+            //Act
+            testable.ProcessRequest(httpContextMock.Object);
+
+            //Asert
+            Assert.AreEqual(500, response.Object.StatusCode);
+            Assert.AreEqual(expectedJsonResponse, responseContent);
+        }
+
+        #endregion
+
+        #region FeatureSwitch Service (GET methods)
+
+        [Test]
+        public void ApiGetReturns200AndValidJsonArrayOfAllInitialisedFeatureSwitchesFromFeatureSwitchService()
         {
             //Arrange
             var testable = new TestableFemahApiHttpHandler();
@@ -139,11 +273,8 @@ namespace Femah.Core.Tests
                 })
             };
 
-            //Serialise for comparing what we get back from the API
-            //using our extension method
-            var featureSwitchesJson = featureSwitches.ToJson();
-            //or directly with JSON.NET?
-            //var featureSwitchesJson = JsonConvert.SerializeObject(featureSwitches);
+            const string expectedJsonResponse =
+                "[{\"IsEnabled\":false,\"Name\":\"TestFeatureSwitch1\",\"FeatureType\":\"SimpleFeatureSwitch\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"},{\"IsEnabled\":false,\"Name\":\"TestFeatureSwitch2\",\"FeatureType\":\"SimpleFeatureSwitch\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"}]";
 
             var providerMock = new Mock<IFeatureSwitchProvider>();
             providerMock.Setup(p => p.AllFeatureSwitches())
@@ -162,12 +293,109 @@ namespace Femah.Core.Tests
             testable.ProcessRequest(httpContextMock.Object);
 
             //Asert
-            Assert.AreEqual(featureSwitchesJson, responseContent);
+            Assert.AreEqual(200, response.Object.StatusCode);
+            Assert.AreEqual(expectedJsonResponse, responseContent);
 
         }
 
         [Test]
-        public void ApiGetResponseReturnsValidCollectionOfFeatureSwitchTypes()
+        public void ApiGetReturns200AndValidJsonForSingleFeatureSwitchFoundWithinFeatureSwitchService()
+        {
+            //Arrange
+            var testable = new TestableFemahApiHttpHandler();
+
+            var httpContextMock = new Mock<HttpContextBase>();
+            httpContextMock.Setup(x => x.Request.Url)
+                .Returns(new Uri("http://example.com/femah.axd/api/featureswitch/TestFeatureSwitch1"));
+            httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("GET");
+
+            var response = new Mock<HttpResponseBase>();
+            response.SetupProperty(x => x.StatusCode);
+            httpContextMock.Setup(x => x.Response).Returns(response.Object);
+
+            var featureSwitch = new SimpleFeatureSwitch
+            {
+                Name = "TestFeatureSwitch1",
+                IsEnabled = false,
+                FeatureType = "SimpleFeatureSwitch"
+            };
+
+            const string expectedJsonResponse =
+                "[{\"IsEnabled\":false,\"Name\":\"TestFeatureSwitch1\",\"FeatureType\":\"SimpleFeatureSwitch\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"}]";
+
+            var providerMock = new Mock<IFeatureSwitchProvider>();
+            providerMock.Setup(p => p.Get(featureSwitch.Name.ToLower()))
+                .Returns(featureSwitch);
+
+            Femah.Configure()
+                .FeatureSwitchEnum(typeof(FeatureSwitches))
+                .Provider(providerMock.Object)
+                .Initialise();
+
+            //Get the JSON response by intercepting the call to context.Response.Write
+            string responseContent = string.Empty;
+            response.Setup(x => x.Write(It.IsAny<string>())).Callback((string r) => { responseContent = r; });
+
+            //Act
+            testable.ProcessRequest(httpContextMock.Object);
+
+            //Asert
+            Assert.AreEqual(200, response.Object.StatusCode);
+            Assert.AreEqual(expectedJsonResponse, responseContent);
+        }
+
+        [Test]
+        public void ApiGetReturns404AndEmptyResponseBodyIfFeatureSwitchNotfoundWithinFeatureSwitchService()
+        {
+            //Arrange
+            var testable = new TestableFemahApiHttpHandler();
+
+            var httpContextMock = new Mock<HttpContextBase>();
+            httpContextMock.Setup(x => x.Request.Url)
+                .Returns(new Uri("http://example.com/femah.axd/api/featureswitch/unknownfeatureswitch"));
+            httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("GET");
+
+            var response = new Mock<HttpResponseBase>();
+            response.SetupProperty(x => x.StatusCode);
+            httpContextMock.Setup(x => x.Response).Returns(response.Object);
+
+            var featureSwitch = new SimpleFeatureSwitch
+            {
+                Name = "TestFeatureSwitch1",
+                IsEnabled = false,
+                FeatureType = "SimpleFeatureSwitch"
+            };
+
+            const string expectedJsonResponse = "\"\"";
+
+            var providerMock = new Mock<IFeatureSwitchProvider>();
+            providerMock.Setup(p => p.Get(featureSwitch.Name.ToLower()))
+                .Returns(featureSwitch);
+
+            Femah.Configure()
+                .FeatureSwitchEnum(typeof(FeatureSwitches))
+                .Provider(providerMock.Object)
+                .Initialise();
+
+            //Get the JSON response by intercepting the call to context.Response.Write
+            string responseContent = string.Empty;
+            response.Setup(x => x.Write(It.IsAny<string>())).Callback((string r) => { responseContent = r; });
+
+            //Act
+            testable.ProcessRequest(httpContextMock.Object);
+
+            //Asert
+            Assert.AreEqual(404, response.Object.StatusCode);
+            Assert.AreEqual(expectedJsonResponse, responseContent);
+
+        }
+
+        #endregion
+
+        #region FeatureSwitchType Service (GET methods)
+
+        [Test]
+        public void ApiGetReturns200AndValidJsonArrayOfAllInitialisedFeatureSwitchTypesFromFeatureSwitchTypeService()
         {
             //Arrange
             var testable = new TestableFemahApiHttpHandler();
@@ -180,12 +408,12 @@ namespace Femah.Core.Tests
             response.SetupProperty(x => x.StatusCode);
             httpContextMock.Setup(x => x.Response).Returns(response.Object);
 
-            const int numberOfSwitchTypes = 1;
+            const int numberOfSwitchTypes = 2;
             var featureSwitchTypes = new Type[numberOfSwitchTypes];
             featureSwitchTypes[0] = typeof (SimpleFeatureSwitch);
+            featureSwitchTypes[1] = typeof(SimpleFeatureSwitch);
 
-            //Serialise for comparing what we get back from the API
-            var featureSwitchTypesJson = featureSwitchTypes.ToJson();
+            const string expectedJsonResponse = "[{\"Name\":\"SimpleFeatureSwitch\",\"FeatureSwitchType\":\"Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"},{\"Name\":\"SimpleFeatureSwitch\",\"FeatureSwitchType\":\"Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"}]";
 
             Femah.Configure()
                 .WithSelectedFeatureSwitchTypes(featureSwitchTypes)
@@ -200,8 +428,12 @@ namespace Femah.Core.Tests
 
             //Assert
             Assert.AreEqual(200, response.Object.StatusCode);
-            Assert.AreEqual(featureSwitchTypesJson, responseContent);
+            Assert.AreEqual(expectedJsonResponse, responseContent);
 
         }
+
+        #endregion
+
+
     }
 }

--- a/Femah.Core/Api/ApiFeatureSwitchType.cs
+++ b/Femah.Core/Api/ApiFeatureSwitchType.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Femah.Core.Api
+{
+    public class ApiFeatureSwitchType
+    {
+        public string Name { get; set; }
+        public Type FeatureSwitchType { get; set; }
+        public string Description { get; set; }
+        public string ConfigurationInstructions { get; set; }
+    }
+}

--- a/Femah.Core/Api/ApiRequest.cs
+++ b/Femah.Core/Api/ApiRequest.cs
@@ -2,12 +2,12 @@
 {
     public class ApiRequest
     {
-        public ApiCollection Collection { get; set; }
-        public string Member { get; set; }
+        public ApiService? Service { get; set; }
+        public string Parameter { get; set; }
         public string HttpMethod { get; set; }
         public string ErrorMessage { get; set; }
 
-        public enum ApiCollection
+        public enum ApiService
         {
             featureswitch,
             featureswitches,

--- a/Femah.Core/Api/ApiResponse.cs
+++ b/Femah.Core/Api/ApiResponse.cs
@@ -1,0 +1,14 @@
+﻿namespace Femah.Core.Api
+{
+    public class ApiResponse
+    {
+        public string Body { get; set; }
+        public int HttpStatusCode { get; set; }
+
+        public ApiResponse()
+        {
+            Body = string.Empty;
+        }
+
+    }
+}

--- a/Femah.Core/Api/ApiResponseBuilder.cs
+++ b/Femah.Core/Api/ApiResponseBuilder.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using Femah.Core.ExtensionMethods;
+
+namespace Femah.Core.Api
+{
+    public class ApiResponseBuilder : IDisposable
+    {
+        private IEnumerable<Type> _featureSwitchTypes;
+        private IEnumerable<IFeatureSwitch> _featureSwitches;
+        private ApiRequest _apiRequest;
+        private string _body;
+        private HttpStatusCode _httpStatusCode;
+
+        #region IDisposable
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        /// <filterpriority>2</filterpriority>
+        public void Dispose()
+        {
+
+        }
+
+        #endregion
+
+        public ApiResponseBuilder CreateWithFeatureSwitchTypes(IEnumerable<Type> featureSwitchTypes)
+        {
+            _featureSwitchTypes = featureSwitchTypes;
+            return this;
+        }
+
+        public ApiResponseBuilder CreateWithFeatureSwitches(IFeatureSwitch featureSwitch)
+        {
+            var fs = new List<IFeatureSwitch> {featureSwitch};
+            _featureSwitches = fs;
+            return this;
+        }
+
+        public ApiResponseBuilder CreateWithFeatureSwitches(IEnumerable<IFeatureSwitch> featureSwitches)
+        {
+            _featureSwitches = featureSwitches;
+            return this;
+        }
+
+        public ApiResponseBuilder WithApiRequest(ApiRequest apiRequest)
+        {
+            _apiRequest = apiRequest;
+            return this;
+        }
+
+        public ApiResponseBuilder WithBody(string body)
+        {
+            _body = body;
+            return this;
+        }
+
+        public ApiResponseBuilder WithHttpStatusCode(HttpStatusCode httpStatusCode)
+        {
+            _httpStatusCode = httpStatusCode;
+            return this;
+        }
+
+        /// <summary>
+        /// An implicit operator to save us having to use somehting like .Build() at the end of the fluent chain.
+        /// The heart and soul of the fluent builder, determines which methods were chained together and handles the logic to 
+        /// build the ApiResponse object in its entirety.
+        /// </summary>
+        /// <param name="apiResponseBuilder"></param>
+        /// <returns></returns>
+        public static implicit operator ApiResponse(ApiResponseBuilder apiResponseBuilder)
+        {
+
+            if (apiResponseBuilder._body != null && apiResponseBuilder._httpStatusCode > 0)
+            {
+                //WithBody and WithHttpStatusCode defined
+                return SetResponseProperties(apiResponseBuilder._body.ToJson(), apiResponseBuilder._httpStatusCode);
+            }
+
+            if (apiResponseBuilder._featureSwitchTypes != null)
+            {
+                //CreateWithFeatureSwitchTypes defined
+                var apiFeatureSwitchTypes = new List<ApiFeatureSwitchType>();
+                try
+                {
+                    foreach (var featureSwitchType in apiResponseBuilder._featureSwitchTypes)
+                    {
+                        var featureSwitchTypeInstance = (IFeatureSwitch) Activator.CreateInstance(featureSwitchType);
+                        var apiFeatureSwitchType = new ApiFeatureSwitchType
+                        {
+                            FeatureSwitchType = featureSwitchType,
+                            ConfigurationInstructions = featureSwitchTypeInstance.ConfigurationInstructions,
+                            Description = featureSwitchTypeInstance.Description,
+                            Name = featureSwitchType.Name
+                        };
+                        apiFeatureSwitchTypes.Add(apiFeatureSwitchType);
+                    }
+
+                    return SetResponseProperties(apiFeatureSwitchTypes.ToJson(), HttpStatusCode.OK);
+                }
+                catch (Exception exception)
+                {
+                    return SetResponseProperties(exception.InnerException.ToJson(), HttpStatusCode.InternalServerError);
+                }
+            }
+
+            if (apiResponseBuilder._featureSwitches != null)
+            {
+                //CreateWithFeatureSwitches defined
+                try
+                {
+                    return SetResponseProperties(apiResponseBuilder._featureSwitches.ToJson(), HttpStatusCode.OK);
+                }
+                catch (Exception exception)
+                {
+                    return SetResponseProperties(exception.InnerException.ToJson(), HttpStatusCode.InternalServerError);
+                }
+            }
+
+            return SetResponseProperties(string.Empty, HttpStatusCode.NotFound);
+        }
+
+        /// <summary>
+        /// A small helper method to make it a little nicer to new up an ApiResponse object.
+        /// </summary>
+        /// <param name="body" type="string">The ApiResponse body, expected to be JSON serialised.</param>
+        /// <param name="httpStatusCode" type="HttpStatusCode">The HTTP StatusCode we want to set within the ApiResponse.</param>
+        /// <returns></returns>
+        private static ApiResponse SetResponseProperties(string body, HttpStatusCode httpStatusCode)
+        {
+            //TODO: Use JSON.NET to validate if the Body is JSON??
+            return new ApiResponse { Body = body, HttpStatusCode = (int)httpStatusCode };
+        }
+
+
+    }
+}

--- a/Femah.Core/FeatureSwitchTypes/FeatureSwitchBase.cs
+++ b/Femah.Core/FeatureSwitchTypes/FeatureSwitchBase.cs
@@ -48,5 +48,16 @@ namespace Femah.Core.FeatureSwitchTypes
         {
             return;
         }
+
+        public virtual string Description
+        {
+
+            get { return "Define a short description of the feature switch type here."; }
+        }
+
+        public virtual string ConfigurationInstructions
+        {
+            get { return "Add configuration context and instructions to be displayed in the admin UI"; }
+        }
     }
 }

--- a/Femah.Core/FeatureSwitchTypes/PercentageFeatureSwitch.cs
+++ b/Femah.Core/FeatureSwitchTypes/PercentageFeatureSwitch.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using System.Text;
 using System.Web;
 using System.Web.UI;
 
@@ -92,6 +90,16 @@ namespace Femah.Core.FeatureSwitchTypes
         }
 
         #endregion
+        public override string Description
+        {
+
+            get { return "A simple feature switch that is on for a set percentage of users. The state of the switch is persisted in the user's cookies.If no cookie exists the state is chosen at random (weighted according to the percentage), and then stored in a cookie."; }
+        }
+
+        public override string ConfigurationInstructions
+        {
+            get { return "Set PercentageOn to the percentage of users who should see this feature. Eg. 10 means the feature is on for 10% of users."; }
+        }
 
     }
 }

--- a/Femah.Core/FeatureSwitchTypes/RoleBasedFeatureSwitch.cs
+++ b/Femah.Core/FeatureSwitchTypes/RoleBasedFeatureSwitch.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Linq;
-using System.Text;
 
 namespace Femah.Core.FeatureSwitchTypes
 {

--- a/Femah.Core/Femah.Core.csproj
+++ b/Femah.Core/Femah.Core.csproj
@@ -26,7 +26,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>BuildOutput\$(TargetFrameworkVersion)</OutputPath>
+    <OutputPath>BuildOutput\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -45,7 +45,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Api\ApiFeatureSwitchType.cs" />
+    <Compile Include="Api\ApiResponseBuilder.cs" />
     <Compile Include="Api\ApiRequest.cs" />
+    <Compile Include="Api\ApiResponse.cs" />
     <Compile Include="Api\FemahApiHttpHandler.cs" />
     <Compile Include="ExtensionMethods\EnumExtensions.cs" />
     <Compile Include="ExtensionMethods\StringExtensions.cs" />

--- a/Femah.Core/Femah.Core.nuspec
+++ b/Femah.Core/Femah.Core.nuspec
@@ -18,6 +18,6 @@
     </dependencies>
   </metadata>
   <files>
-	<file src="BuildOutput\**\Femah.Core.dll" target="\lib\Net45"/>
+	<file src="BuildOutput\**\Femah.Core.dll" target="\lib\Net35"/>
   </files>
 </package>

--- a/Femah.Core/IFeatureSwitch.cs
+++ b/Femah.Core/IFeatureSwitch.cs
@@ -35,5 +35,9 @@ namespace Femah.Core
         /// </summary>
         /// <param name="values">A collection of key-value pairs.</param>
         void SetCustomAttributes(NameValueCollection values);
+
+        string Description { get; }
+
+        string ConfigurationInstructions { get; }
     }
 }


### PR DESCRIPTION
#24 API integration to support Admin UI and basic use cases
- Bug. Changed ApiRequest ApiCollection to be nullable so the first enum
  didn't always populate the collection, even when there is no match.
- Introduced the fluent ApiResponseBuilder, refactored all response
  building logic to ApiResponseBuilder from FemahApiHttpHandler
- Modifed API to return 404's instead of 500's for missing items such as
  invalid collections
- Renamed API Collection to Service
- Renamed API Member to Parameter
- Added better unit test coverage for API edge cases
#33 Should Feature Switch types contain a description?
- As part of ApiResponseBuilder (#24), I also added an ApiReponse class
  (containing a string body and int HTTP status code) to simplify building
  up and responding to an API request.
- Implemented ApiFeatureSwitchType, a custom class to allow us to
  serialise a JSON response containing the FeatureSwitch Type, Name,
  Description and ConfigurationInformation, the serialisation of this
  class is then returned as the ApiReponse.Body from the
  ApiResponseBuilder.
