### PR TITLE
#24 API integration to support Admin UI and basic use cases

### DIFF
--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Net;
 using System.Text;
 using System.Web;
 using Femah.Core.Api;
@@ -23,6 +25,171 @@ namespace Femah.Core.Tests
         {
             SomeNewFeature = 1
         }
+
+        #region ApiRequestBuilder
+
+        [Test]
+        public void ApiRequestBuilderSetsApiRequestBodyIfHttpContextInputStreamIsNotNull()
+        {
+            //Arrange
+            var testable = new ApiRequestBuilder();
+
+            var httpContextMock = new Mock<HttpContextBase>();
+            httpContextMock.Setup(x => x.Request.Url)
+                .Returns(new Uri("http://example.com/femah.axd/api/featureswitches"));
+            httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("GET");
+
+            //Build the request Body in JSON
+            const string expectedJsonBody = "{\"IsEnabled\":true,\"Name\":\"TestFeatureSwitch1\",\"FeatureType\":\"SimpleFeatureSwitch\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"}";
+            var inputStream = new MemoryStream();
+            var streamWriter = new StreamWriter(inputStream);
+            streamWriter.Write(expectedJsonBody);
+            streamWriter.Flush();
+
+            httpContextMock.SetupGet(x => x.Request.InputStream).Returns(inputStream);
+
+            //Act
+            ApiRequest apiRequest = testable.Build(httpContextMock.Object.Request);
+            
+            //Assert
+            Assert.AreEqual(expectedJsonBody, apiRequest.Body);
+        }
+
+        [Test]
+        public void ApiRequestBuilderSetsErrorMessageHttpStatusCodeTo415AndProvidesAccurateErrorMessageIfContentTypeIsNotSetToApplicationJsonAndRequestIsAPut()
+        {
+            //Arrange
+            var testable = new ApiRequestBuilder();
+            
+            var httpContextMock = new Mock<HttpContextBase>();
+            httpContextMock.Setup(x => x.Request.Url)
+                .Returns(new Uri("http://example.com/femah.axd/api/featureswitch/TestFeatureSwitch1"));
+            httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("PUT");
+            httpContextMock.SetupGet(x => x.Request.ContentType).Returns("incorrect/contenttype");
+
+            const string expectedJsonBody = "Error: Content-Type 'incorrect/contenttype' of request is not supported, expecting 'application/json'.";
+
+            //Act
+            ApiRequest apiRequest = testable.Build(httpContextMock.Object.Request);
+
+            //Asert
+            Assert.AreEqual(HttpStatusCode.UnsupportedMediaType, apiRequest.ErrorMessageHttpStatusCode);
+            Assert.AreEqual(expectedJsonBody, apiRequest.ErrorMessage);
+        }
+        
+        [Test]
+        public void ApiRequestBuilderSetsErrorMessageHttpStatusCodeTo500AndProvidesAccurateErrorMessageIfRequestUrlIsInvalidAndContainsTooManySegments()
+        {
+            //Arrange
+            var testable = new ApiRequestBuilder();
+
+            var httpContextMock = new Mock<HttpContextBase>();
+            httpContextMock.Setup(x => x.Request.Url)
+                .Returns(new Uri("http://example.com/femah.axd/api/invalid/url/structure"));
+            httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("GET");
+
+            const string expectedJsonBody = "Error: The requested Url 'http://example.com/femah.axd/api/invalid/url/structure' does not match the expected format /femah.axd/api/[service]/[parameter].";
+
+            //Act
+            ApiRequest apiRequest = testable.Build(httpContextMock.Object.Request);
+
+            //Asert
+            Assert.AreEqual(HttpStatusCode.InternalServerError, apiRequest.ErrorMessageHttpStatusCode);
+            Assert.AreEqual(expectedJsonBody, apiRequest.ErrorMessage);
+        }
+
+        [Test]
+        public void ApiRequestBuilderSetsErrorMessageHttpStatusCodeTo500AndProvidesAccurateErrorMessageIfRequestUrlIsInvalidAndContainsTooFewSegments()
+        {
+            //Arrange
+            var testable = new ApiRequestBuilder();
+
+            var httpContextMock = new Mock<HttpContextBase>();
+            httpContextMock.Setup(x => x.Request.Url)
+                .Returns(new Uri("http://example.com/femah.axd/api"));
+            httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("GET");
+
+            const string expectedJsonBody = "Error: The requested Url 'http://example.com/femah.axd/api' does not match the expected format /femah.axd/api/[service]/[parameter].";
+
+            //Act
+            ApiRequest apiRequest = testable.Build(httpContextMock.Object.Request);
+
+            //Asert
+            Assert.AreEqual(HttpStatusCode.InternalServerError, apiRequest.ErrorMessageHttpStatusCode);
+            Assert.AreEqual(expectedJsonBody, apiRequest.ErrorMessage);
+        }
+        
+        #endregion
+
+        #region ProcessApiRequest
+
+        [Test]
+        public void ProcessPutRequestSetsHttpStatusCodeTo405AndProvidesAccurateErrorMessageInBodyIfPutRequestIsMissingParameter()
+        {
+            //Arrange
+            var apiRequest = new ApiRequest
+            {
+                HttpMethod = "PUT",
+                Service = ApiRequest.ApiService.featureswitch,
+            };
+
+            const string expectedJsonBody = "\"Error: Service 'featureswitch' requires a parameter to be passed. Url must match the format /femah.axd/api/[service]/[parameter].\"";
+
+            //Act
+            ApiResponse apiResponse = ProcessApiRequest.ProcessPutRequest(apiRequest);
+
+            //Assert
+            Assert.AreEqual((int)HttpStatusCode.MethodNotAllowed, apiResponse.HttpStatusCode);
+            Assert.AreEqual(expectedJsonBody, apiResponse.Body);
+        }
+
+        [Test]
+        public void ProcessPutRequestSetsHttpStatusCodeTo405AndProvidesAccurateErrorMessageInResponseBodyIfPutRequestIsNotForFeatureSwitchService()
+        {
+            //Arrange
+            var apiRequest = new ApiRequest
+            {
+                HttpMethod = "PUT",
+                Service = ApiRequest.ApiService.featureswitchtypes,
+                Parameter = "TestFeatureSwitch"
+            };
+
+            const string expectedJsonBody = "\"Error: Service 'featureswitchtypes' does not support parameter querying.\"";
+
+            //Act
+            ApiResponse apiResponse = ProcessApiRequest.ProcessPutRequest(apiRequest);
+
+            //Assert
+            Assert.AreEqual((int)HttpStatusCode.MethodNotAllowed, apiResponse.HttpStatusCode);
+            Assert.AreEqual(expectedJsonBody, apiResponse.Body);
+        }
+
+        [Test]
+        public void ProcessPutRequestSetsHttpStatusCodeTo400AndProvidesAccurateErrorMessageInResponseBodyIfPutRequestBodyContainsAnInvalidFeatureType()
+        {
+            //Arrange
+            const string invalidFeatureType = "Invalid.FeatureType.Will.Not.Deserialise";
+            string validFeatureType = "Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null";
+            //const string json = "{{\"IsEnabled\":true,\"Name\":\"TestFeatureSwitch1\",\"FeatureType\":\"{0}\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"}}";
+            var apiRequest = new ApiRequest
+            {
+                HttpMethod = "PUT",
+                Service = ApiRequest.ApiService.featureswitch,
+                Parameter = "TestFeatureSwitch",
+                Body = string.Format("{{\"IsEnabled\":true,\"Name\":\"TestFeatureSwitch1\",\"FeatureType\":\"{0}\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"}}", invalidFeatureType)
+            };
+
+            const string expectedJsonBody = "\"Error: Unable to deserialise the request body using the supplied 'FeatureType' value, have you used the AssemblyQualifiedName in your request?\"";
+
+            //Act
+            ApiResponse apiResponse = ProcessApiRequest.ProcessPutRequest(apiRequest);
+
+            //Assert
+            Assert.AreEqual((int)HttpStatusCode.BadRequest, apiResponse.HttpStatusCode);
+            Assert.AreEqual(expectedJsonBody, apiResponse.Body);
+        }
+
+        #endregion
 
         #region General API (GET methods)
 
@@ -146,6 +313,7 @@ namespace Femah.Core.Tests
         }
 
         [Test]
+        [Ignore("We are now testing this in the ApiRequesteBuilder(), keep this as an integration test maybe?")]
         public void ApiGetReturns500AndAccurateErrorMessageIfRequestUrlIsInvalidAndContainsTooManySegments()
         {
             //apiRequest.ErrorMessage = string.Format("Error: The requested Url: '{0}' does not match the expected format /femah.axd/api/[service]/[parameter]", request.Url);
@@ -193,6 +361,7 @@ namespace Femah.Core.Tests
         }
 
         [Test]
+        [Ignore("We are now testing this in the ApiRequesteBuilder(), keep this as an integration test maybe?")]
         public void ApiGetReturns500AndAccurateErrorMessageIfRequestUrlIsInvalidAndContainsTooFewSegments()
         {
             //Arrange
@@ -214,8 +383,7 @@ namespace Femah.Core.Tests
                 FeatureType = "SimpleFeatureSwitch"
             };
 
-            const string expectedJsonResponse =
-                "\"Error: The requested Url 'http://example.com/femah.axd/api' does not match the expected format /femah.axd/api/[service]/[parameter].\"";
+            const string expectedJsonResponse = "\"Error: The requested Url 'http://example.com/femah.axd/api' does not match the expected format /femah.axd/api/[service]/[parameter].\"";
 
             var providerMock = new Mock<IFeatureSwitchProvider>();
             providerMock.Setup(p => p.Get(featureSwitch.Name.ToLower()))
@@ -390,6 +558,59 @@ namespace Femah.Core.Tests
 
         }
 
+        #endregion
+
+        #region FeatureSwitch Service (PUT methods)
+
+        [Test]
+        [Ignore("We are now testing this in the ApiRequesteBuilder(), keep this as an integration test maybe?")]
+        public void ApiPutReturns415AndAccurateErrorMessageIfContentTypeIsNotSetToApplicationJson()
+        {
+            //Arrange
+            var testable = new TestableFemahApiHttpHandler();
+
+            var httpContextMock = new Mock<HttpContextBase>();
+            httpContextMock.Setup(x => x.Request.Url)
+                .Returns(new Uri("http://example.com/femah.axd/api/featureswitch/TestFeatureSwitch1"));
+            httpContextMock.SetupGet(x => x.Request.HttpMethod).Returns("PUT");
+            httpContextMock.SetupGet(x => x.Request.ContentType).Returns("incorrect/contenttype");
+
+
+            var response = new Mock<HttpResponseBase>();
+            response.SetupProperty(x => x.StatusCode);
+            httpContextMock.Setup(x => x.Response).Returns(response.Object);
+
+            var featureSwitch = new SimpleFeatureSwitch
+            {
+                Name = "TestFeatureSwitch1",
+                IsEnabled = false,
+                FeatureType = "SimpleFeatureSwitch"
+            };
+
+            const string expectedJsonResponse = "\"Error: Content-Type 'incorrect/contenttype' of request is not supported, expecting 'application/json'.\"";
+
+            var providerMock = new Mock<IFeatureSwitchProvider>();
+            providerMock.Setup(p => p.Get(featureSwitch.Name.ToLower()))
+                .Returns(featureSwitch);
+
+            Femah.Configure()
+                .FeatureSwitchEnum(typeof(FeatureSwitches))
+                .Provider(providerMock.Object)
+                .Initialise();
+
+            //Get the JSON response by intercepting the call to context.Response.Write
+            string responseContent = string.Empty;
+            response.Setup(x => x.Write(It.IsAny<string>())).Callback((string r) => { responseContent = r; });
+
+            //Act
+            testable.ProcessRequest(httpContextMock.Object);
+
+            //Asert
+            Assert.AreEqual(415, response.Object.StatusCode);
+            Assert.AreEqual(expectedJsonResponse, responseContent);
+        }
+
+        
         #endregion
 
         #region FeatureSwitchType Service (GET methods)

--- a/Femah.Core/Api/ApiRequest.cs
+++ b/Femah.Core/Api/ApiRequest.cs
@@ -1,17 +1,20 @@
-﻿namespace Femah.Core.Api
+﻿using System.Net;
+
+namespace Femah.Core.Api
 {
     public class ApiRequest
     {
         public ApiService? Service { get; set; }
         public string Parameter { get; set; }
         public string HttpMethod { get; set; }
+        public string Body { get; set; }
         public string ErrorMessage { get; set; }
+        public HttpStatusCode ErrorMessageHttpStatusCode { get; set; }
 
         public enum ApiService
         {
             featureswitch,
             featureswitches,
-            featureswitchtype,
             featureswitchtypes
         }
     }

--- a/Femah.Core/Api/ApiRequestBuilder.cs
+++ b/Femah.Core/Api/ApiRequestBuilder.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Web;
+using Femah.Core.ExtensionMethods;
+
+namespace Femah.Core.Api
+{
+    public class ApiRequestBuilder : IDisposable
+    {
+        #region IDisposable
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        /// <filterpriority>2</filterpriority>
+        public void Dispose()
+        {
+
+        }
+
+        #endregion
+
+        public ApiRequest Build(HttpRequestBase request)
+        {
+            var apiRequest = new ApiRequest();
+            if (request.HttpMethod == "PUT" && request.ContentType != "application/json")
+            {
+                apiRequest.ErrorMessage = string.Format("Error: Content-Type '{0}' of request is not supported, expecting 'application/json'.", request.ContentType);
+                apiRequest.ErrorMessageHttpStatusCode = HttpStatusCode.UnsupportedMediaType;
+                return apiRequest;
+            }
+
+            if (request.Url == null)
+            {
+                apiRequest.ErrorMessage = string.Format("Error: The requested Url '{0}' is null.", request.Url);
+                apiRequest.ErrorMessageHttpStatusCode = HttpStatusCode.InternalServerError;
+                return apiRequest;
+            }
+
+            var uriSegments = request.Url.Segments;
+
+            try
+            {
+                apiRequest.HttpMethod = request.HttpMethod;
+
+                //If we have a request body then retrieve it from the InputStream.
+                if (request.InputStream != null)
+                {
+                    string requestBody;
+                    using (var stream = new MemoryStream())
+                    {
+                        request.InputStream.Seek(0, SeekOrigin.Begin);
+                        request.InputStream.CopyTo(stream);
+                        requestBody = Encoding.UTF8.GetString(stream.ToArray());
+                    }
+                    apiRequest.Body = requestBody;
+                }
+
+                if (uriSegments.Count() < 4 || uriSegments.Count()> 5)
+                {
+                    apiRequest.ErrorMessage = string.Format("Error: The requested Url '{0}' does not match the expected format /femah.axd/api/[service]/[parameter].", request.Url);
+                    apiRequest.ErrorMessageHttpStatusCode = HttpStatusCode.InternalServerError;
+                    return apiRequest;
+                }
+
+                //Retrieve the service passed in on the Url, service is mandatory.
+                string service = uriSegments[3].ToLower().Replace("/", "");
+
+                ApiRequest.ApiService apiService;
+                if (EnumExtensions.TryParse(service, out apiService))
+                {
+                    if (Enum.IsDefined(typeof (ApiRequest.ApiService), apiService))
+                        apiRequest.Service = apiService;
+                }
+                else
+                {
+                    apiRequest.Service = null;
+                }
+
+                if (uriSegments.Count() == 5)
+                {
+                    //Retrieve the optional parameter of the service passed in on the Url, this is optional so handle this a little better.
+                    string member = uriSegments[4].ToLower().Replace("/", "");
+                    apiRequest.Parameter = member;
+                }
+
+            }
+            catch (IndexOutOfRangeException)
+            {
+                apiRequest.ErrorMessage = string.Format("Error: The requested Url '{0}' does not match the expected format /femah.axd/api/[service]/[parameter].", request.Url);
+                apiRequest.ErrorMessageHttpStatusCode = HttpStatusCode.InternalServerError;
+            }
+
+            return apiRequest;
+        }
+    }
+}

--- a/Femah.Core/Api/ApiResponseBuilder.cs
+++ b/Femah.Core/Api/ApiResponseBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using Femah.Core.ExtensionMethods;
+using Newtonsoft.Json;
 
 namespace Femah.Core.Api
 {
@@ -35,6 +36,13 @@ namespace Femah.Core.Api
         public ApiResponseBuilder CreateWithFeatureSwitches(IFeatureSwitch featureSwitch)
         {
             var fs = new List<IFeatureSwitch> {featureSwitch};
+            _featureSwitches = fs;
+            return this;
+        }
+
+        public ApiResponseBuilder CreateWithUpdatedFeatureSwitch(IFeatureSwitch featureSwitch)
+        {
+            var fs = new List<IFeatureSwitch> { featureSwitch };
             _featureSwitches = fs;
             return this;
         }
@@ -133,6 +141,8 @@ namespace Femah.Core.Api
             //TODO: Use JSON.NET to validate if the Body is JSON??
             return new ApiResponse { Body = body, HttpStatusCode = (int)httpStatusCode };
         }
+
+
 
 
     }

--- a/Femah.Core/Api/FemahApiHttpHandler.cs
+++ b/Femah.Core/Api/FemahApiHttpHandler.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Linq;
-using System.Net;
+﻿using System.Net;
 using System.Text;
 using System.Web;
-using Femah.Core.ExtensionMethods;
 
 namespace Femah.Core.Api
 {
@@ -25,8 +22,12 @@ namespace Femah.Core.Api
             context.Response.ContentEncoding = Encoding.UTF8;
 
             // Great article on verbs to use in API design http://stackoverflow.com/questions/2001773/understanding-rest-verbs-error-codes-and-authentication/2022938#2022938
+            ApiRequest apiRequest;
+            using (var apiRequestBuilder = new ApiRequestBuilder())
+            {
+                apiRequest = apiRequestBuilder.Build(context.Request);
+            }
             
-            var apiRequest = BuildApiRequest(context.Request);
             var apiResponse = new ApiResponse();
 
             if (!string.IsNullOrEmpty(apiRequest.ErrorMessage))
@@ -35,7 +36,7 @@ namespace Femah.Core.Api
                 {
                     apiResponse = apiResponseBuilder.WithBody(
                             string.Format(apiRequest.ErrorMessage))
-                            .WithHttpStatusCode(HttpStatusCode.InternalServerError);
+                            .WithHttpStatusCode(apiRequest.ErrorMessageHttpStatusCode);
                 }
             }
             else
@@ -43,10 +44,10 @@ namespace Femah.Core.Api
                 switch (apiRequest.HttpMethod)
                 {
                     case "GET":
-                        apiResponse = ProcessApiGetRequest(context, apiRequest);
+                        apiResponse = ProcessApiRequest.ProcessGetRequest(apiRequest);
                         break;
                     case "PUT":
-                        apiResponse = ProcessApiPutRequest(context, apiRequest);
+                        apiResponse = ProcessApiRequest.ProcessPutRequest(apiRequest);
                         break;
                 }
 
@@ -60,128 +61,8 @@ namespace Femah.Core.Api
                     }
                 }
             }
-
             context.Response.StatusCode = apiResponse.HttpStatusCode;
             context.Response.Write(apiResponse.Body);
         }
-
-        /// <summary>
-        /// Responsible for processing all HTTP GET requests in to the femah API. Orchestrates and hands off to appropriate builders 
-        /// to create request and response objects.
-        /// </summary>
-        /// <param name="context" type="HttpContextBase">The current http context, required to allow us to write the API response back on the response object.</param>
-        /// <param name="apiRequest" type="ApiRequest">A custom request object built predominantly from the http context request object, contains everything we need to route the API request appropriately.</param>
-        /// <returns type="ApiResponse">The complete response to the GET request from the API, including body and HTTP status code.</returns>
-        private static ApiResponse ProcessApiGetRequest(HttpContextBase context, ApiRequest apiRequest)
-        {
-            using (var apiResponseBuilder = new ApiResponseBuilder())
-            {
-                ApiResponse response;
-                if (string.IsNullOrEmpty(apiRequest.Parameter))
-                {
-                    //Example GET: http://example.com/femah.axd/api/featureswitches - Lists all Feature Switches FeatureSwitching.AllFeatures()
-                    //Example GET: http://example.com/femah.axd/api/featureswitchtypes - Lists all Feature Switch Types FeatureSwitching.AllSwitchTypes()
-
-                    switch (apiRequest.Service)
-                    {
-                        case ApiRequest.ApiService.featureswitches:
-                            response = apiResponseBuilder.CreateWithFeatureSwitches(Femah.AllFeatures())
-                                .WithApiRequest(apiRequest);
-                            break;
-                        case ApiRequest.ApiService.featureswitchtypes:
-                            response = apiResponseBuilder.CreateWithFeatureSwitchTypes(Femah.AllSwitchTypes())
-                                .WithApiRequest(apiRequest);
-                            break;
-                        default:
-                            response = apiResponseBuilder.WithBody(string.Empty)
-                                .WithHttpStatusCode(HttpStatusCode.NotFound);
-                            break;
-                    }
-                    return response;
-                }
-
-                //Example GET: http://example.com/femah.axd/api/featureswitch/improvedcheckout - Retrieve the Feature Switch ImprovedCheckout
-                switch (apiRequest.Service)
-                {
-                    case ApiRequest.ApiService.featureswitch:
-
-                        var featureSwitch = Femah.GetFeature(apiRequest.Parameter);
-                        if (featureSwitch != null)
-                        {
-                            response = apiResponseBuilder.CreateWithFeatureSwitches(featureSwitch)
-                                .WithApiRequest(apiRequest);
-                            break;
-                        }
-                        response = apiResponseBuilder.WithBody(string.Empty)
-                                .WithHttpStatusCode(HttpStatusCode.NotFound);
-                            break;
-                    default:
-                        response = apiResponseBuilder.WithBody(
-                                string.Format("Error: Service '{0}' does not support parameter querying.", apiRequest.Service))
-                                .WithHttpStatusCode(HttpStatusCode.MethodNotAllowed);
-                            break;
-                }
-                return response;
-            }
-        }
-
-        private static ApiResponse ProcessApiPutRequest(HttpContextBase context, ApiRequest apiRequest)
-        {
-            throw new NotImplementedException();
-        }
-
-        private static ApiRequest BuildApiRequest(HttpRequestBase request)
-        {
-            var apiRequest = new ApiRequest();
-            if (request.Url == null)
-            {
-                apiRequest.ErrorMessage = string.Format("Error: The requested Url '{0}' is null.", request.Url);
-                return apiRequest;
-            }
-
-            var uriSegments = request.Url.Segments;
-            
-            try
-            {
-                apiRequest.HttpMethod = request.HttpMethod;
-                
-                if (uriSegments.Count() < 4 || uriSegments.Count()> 5)
-                {
-                    apiRequest.ErrorMessage = string.Format("Error: The requested Url '{0}' does not match the expected format /femah.axd/api/[service]/[parameter].", request.Url);
-                    return apiRequest;
-                }
-
-                //Retrieve the service passed in on the Url, service is mandatory.
-                string service = uriSegments[3].ToLower().Replace("/", "");
-
-                ApiRequest.ApiService apiService;
-                if (EnumExtensions.TryParse(service, out apiService))
-                {
-                    if (Enum.IsDefined(typeof (ApiRequest.ApiService), apiService))
-                        apiRequest.Service = apiService;
-                }
-                else
-                {
-                    apiRequest.Service = null;
-                }
-
-                if (uriSegments.Count() == 5)
-                {
-                    //Retrieve the optional parameter of the service passed in on the Url, this is optional so handle this a little better.
-                    string member = uriSegments[4].ToLower().Replace("/", "");
-                    apiRequest.Parameter = member;
-                }
-
-            }
-            catch (IndexOutOfRangeException)
-            {
-                apiRequest.ErrorMessage = string.Format("Error: The requested Url '{0}' does not match the expected format /femah.axd/api/[service]/[parameter].", request.Url);
-            }
-
-            return apiRequest;
-        }
-
-
     }
-
 }

--- a/Femah.Core/Api/ProcessApiRequest.cs
+++ b/Femah.Core/Api/ProcessApiRequest.cs
@@ -1,0 +1,150 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using Femah.Core.FeatureSwitchTypes;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Bson;
+
+namespace Femah.Core.Api
+{
+    public static class ProcessApiRequest
+    {
+        /// <summary>
+        /// Responsible for processing all HTTP GET requests in to the femah API. Receives an ApiRequest object, orchestrates and hands off to 
+        /// the ApiResponseBuilder class to create the ApiResponse object.
+        /// </summary>
+        /// <param name="apiRequest" type="ApiRequest">A custom request object built predominantly from the http context request object, contains everything we need to route the API request appropriately.</param>
+        /// <returns type="ApiResponse">The complete response to the GET request from the API, including body and HTTP status code.</returns>
+        public static ApiResponse ProcessGetRequest(ApiRequest apiRequest)
+        {
+            using (var apiResponseBuilder = new ApiResponseBuilder())
+            {
+                ApiResponse response;
+                if (String.IsNullOrEmpty(apiRequest.Parameter))
+                {
+                    //Example GET: http://example.com/femah.axd/api/featureswitches - Lists all Feature Switches FeatureSwitching.AllFeatures()
+                    //Example GET: http://example.com/femah.axd/api/featureswitchtypes - Lists all Feature Switch Types FeatureSwitching.AllSwitchTypes()
+
+                    switch (apiRequest.Service)
+                    {
+                        case ApiRequest.ApiService.featureswitches:
+                            response = apiResponseBuilder.CreateWithFeatureSwitches(Femah.AllFeatures())
+                                .WithApiRequest(apiRequest);
+                            break;
+                        case ApiRequest.ApiService.featureswitchtypes:
+                            response = apiResponseBuilder.CreateWithFeatureSwitchTypes(Femah.AllSwitchTypes())
+                                .WithApiRequest(apiRequest);
+                            break;
+                        default:
+                            response = apiResponseBuilder.WithBody(String.Empty)
+                                .WithHttpStatusCode(HttpStatusCode.NotFound);
+                            break;
+                    }
+                    return response;
+                }
+
+                //Example GET: http://example.com/femah.axd/api/featureswitch/improvedcheckout - Retrieve the Feature Switch ImprovedCheckout
+                switch (apiRequest.Service)
+                {
+                    case ApiRequest.ApiService.featureswitch:
+
+                        var featureSwitch = Femah.GetFeature(apiRequest.Parameter);
+                        if (featureSwitch != null)
+                        {
+                            response = apiResponseBuilder.CreateWithFeatureSwitches(featureSwitch)
+                                .WithApiRequest(apiRequest);
+                            break;
+                        }
+                        response = apiResponseBuilder.WithBody(String.Empty)
+                            .WithHttpStatusCode(HttpStatusCode.NotFound);
+                        break;
+                    default:
+                        response = apiResponseBuilder.WithBody(
+                            String.Format("Error: Service '{0}' does not support parameter querying.", apiRequest.Service))
+                            .WithHttpStatusCode(HttpStatusCode.MethodNotAllowed);
+                        break;
+                }
+                return response;
+            }
+        }
+
+        /// <summary>
+        /// Responsible for processing all HTTP PUT requests in to the femah API. Receives an ApiRequest object, orchestrates and hands off to 
+        /// the ApiResponseBuilder class to create the ApiResponse object.
+        /// </summary>
+        /// <param name="apiRequest" type="ApiRequest">A custom request object built predominantly from the http context request object, contains everything we need to route the API request appropriately.</param>
+        /// <returns type="ApiResponse">The complete response to the PUT request from the API, including body and HTTP status code.</returns>
+        public static ApiResponse ProcessPutRequest(ApiRequest apiRequest)
+        {
+            using (var apiResponseBuilder = new ApiResponseBuilder())
+            {
+                ApiResponse response = null;
+
+                if (String.IsNullOrEmpty(apiRequest.Parameter))
+                {
+                    response = apiResponseBuilder.WithBody(
+                            String.Format("Error: Service '{0}' requires a parameter to be passed. Url must match the format /femah.axd/api/[service]/[parameter].", apiRequest.Service))
+                            .WithHttpStatusCode(HttpStatusCode.MethodNotAllowed);
+                    return response;
+                }
+                switch (apiRequest.Service)
+                {
+                    //Example PUT: http://example.com/femah.axd/api/featureswitch/TestFeatureSwitch1 - Update a single Feature Switch (IsEnabled, SetCustomAttributes, FeatureType) 
+                    case ApiRequest.ApiService.featureswitch:
+                        var featureSwitch = DeSerialiseJsonBodyToFeatureSwitch(apiRequest.Body);
+                        if (featureSwitch != null)
+                            response = apiResponseBuilder.CreateWithUpdatedFeatureSwitch(featureSwitch);
+                        else
+                        {
+                            response = apiResponseBuilder.WithBody("Error: Unable to deserialise the request body using the supplied 'FeatureType' value, have you used the AssemblyQualifiedName in your request?")
+                            .WithHttpStatusCode(HttpStatusCode.BadRequest);
+                        }
+
+                        break;
+                    default:
+                        response = apiResponseBuilder.WithBody(
+                            String.Format("Error: Service '{0}' does not support parameter querying.", apiRequest.Service))
+                            .WithHttpStatusCode(HttpStatusCode.MethodNotAllowed);
+                        break;
+                }
+                return response;
+            }
+        }
+
+        /// <summary>
+        /// A helper method to deserialise a given JSON string to its pre serialised type.
+        /// </summary>
+        /// <param name="requestBody"></param>
+        /// <returns></returns>
+        private static IFeatureSwitch DeSerialiseJsonBodyToFeatureSwitch(string requestBody)
+        {
+            //Get the AssemblyQualifiedName from the 'FeatureType' property of the passed in JSON string.
+            using (JsonReader jsonReader = new JsonTextReader(new StringReader(requestBody)))
+            {
+                string featureType = string.Empty;
+                while (jsonReader.Read())
+                {
+                    if (jsonReader.TokenType == JsonToken.PropertyName && jsonReader.Value.ToString() == "FeatureType")
+                    {
+                        jsonReader.Read();
+                        featureType = jsonReader.Value.ToString();
+                        break;
+                    }
+                }
+
+                if (string.IsNullOrEmpty(featureType))
+                    return null;
+
+                //Recommend using AssemblyQualifiedName in API requests, allowing us to Deserialise feature switch types from external assemblies.
+                Type theType = Type.GetType(featureType);
+                if (theType == null)
+                    return null;
+
+                var featureSwitch = JsonConvert.DeserializeObject(requestBody, theType);
+                return (IFeatureSwitch) featureSwitch;
+            }
+        }
+        
+    }
+}

--- a/Femah.Core/ExtensionMethods/GenericExtensions.cs
+++ b/Femah.Core/ExtensionMethods/GenericExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System.IO;
+
+namespace Femah.Core.ExtensionMethods
+{
+    static public class GenericExtensions
+    {
+        public static void CopyTo(this Stream source, Stream destination)
+        {
+            // TODO: Argument validation
+            byte[] buffer = new byte[16384]; // For example...
+            int bytesRead;
+            while ((bytesRead = source.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                destination.Write(buffer, 0, bytesRead);
+            }
+        }
+    }
+}

--- a/Femah.Core/Femah.Core.csproj
+++ b/Femah.Core/Femah.Core.csproj
@@ -46,11 +46,14 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Api\ApiFeatureSwitchType.cs" />
+    <Compile Include="Api\ApiRequestBuilder.cs" />
     <Compile Include="Api\ApiResponseBuilder.cs" />
     <Compile Include="Api\ApiRequest.cs" />
     <Compile Include="Api\ApiResponse.cs" />
     <Compile Include="Api\FemahApiHttpHandler.cs" />
+    <Compile Include="Api\ProcessApiRequest.cs" />
     <Compile Include="ExtensionMethods\EnumExtensions.cs" />
+    <Compile Include="ExtensionMethods\GenericExtensions.cs" />
     <Compile Include="ExtensionMethods\StringExtensions.cs" />
     <Compile Include="FeatureSwitchTypes\FeatureSwitchBase.cs" />
     <Compile Include="FeatureSwitchTypes\SimpleFeatureSwitch.cs" />


### PR DESCRIPTION
- Refactored FemahApiHttpHandler.BuildApiRequest method out in to
  separate ApiRequestBuilder class.
- Modified ApiRequestBuilder to require Content-Type header be set to
  'application/json' or throw a 415 'Unsupported Media Type HTTP status
  code' for all PUT operations
  (http://www.vinaysahni.com/best-practices-for-a-pragmatic-restful-api#json-requests)
- Refactored some complex API tests in to ApiRequestBuilder specific
  unit tests, simplifying the tests (set the existing tests to ignore as
  we can probably use them for integration tests further down the line).
- Refactored ProcessApiGetRequest and ProcessApiPutRequest methods out
  from the FemahApiHttpHandler and in to their own class
  ProcessApiRequest, mainly to ease testing.
- Added utility DeSerialiseJsonBodyToFeatureSwitch() method to
  ProcessApiRequest class to deserialise the Json body provided by PUT
  requests
