### PR TITLE
#52 - Refactor unit test layout and naming to be more BDD orientated

### DIFF
--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -294,34 +294,6 @@ namespace Femah.Core.Tests
         #endregion
 
         #region ProcessApiRequest
-        
-
-        
-
-        [Test]
-        public void ProcessPutRequestSetsHttpStatusCodeTo400AndReturnsGenericErrorMessageInResponseBodyIfPropertyValueIsInvalidInPutRequestBody()
-        {
-            //Arrange
-            const string invalidIsEnabledProperty = "NotValidBoolean";
-            var apiRequest = new ApiRequest
-            {
-                HttpMethod = "PUT",
-                Service = ApiRequest.ApiService.featureswitch,
-                Parameter = "TestFeatureSwitch",
-                Body = string.Format("{{\"IsEnabled\":{0},\"Name\":\"TestFeatureSwitch1\",\"FeatureType\":\"Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"}}", invalidIsEnabledProperty)
-            };
-
-            //TODO: I'd like this to be a more specific error with regards to formatting
-            const string expectedJsonBody = "\"Error: Unable to deserialise the request body.  Either the JSON is invalid or the supplied 'FeatureType' value is incorrect, have you used the AssemblyQualifiedName as the 'FeatureType' in the request?\"";
-
-            //Act
-            ApiResponse apiResponse = ProcessApiRequest.ProcessPutRequest(apiRequest);
-
-            //Assert
-            Assert.AreEqual((int)HttpStatusCode.BadRequest, apiResponse.HttpStatusCode);
-            Assert.AreEqual(expectedJsonBody, apiResponse.Body);
-        }
-
         [Test]
         public void ProcessPutRequestSetsHttpStatusCodeTo400AndReturnsGenericErrorMessageInResponseBodyIfPutRequestBodyContainsInvalidJson()
         {

--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -295,29 +295,6 @@ namespace Femah.Core.Tests
 
         #region ProcessApiRequest
         [Test]
-        public void ProcessPutRequestSetsHttpStatusCodeTo400AndReturnsGenericErrorMessageInResponseBodyIfPutRequestBodyContainsInvalidJson()
-        {
-            //Arrange
-            var apiRequest = new ApiRequest
-            {
-                HttpMethod = "PUT",
-                Service = ApiRequest.ApiService.featureswitch,
-                Parameter = "TestFeatureSwitch",
-                Body = "This is not JSON"
-            };
-
-            //TODO: I'd like this to be a more specific error with regards to formatting
-            const string expectedJsonBody = "\"Error: Unable to deserialise the request body.  Either the JSON is invalid or the supplied 'FeatureType' value is incorrect, have you used the AssemblyQualifiedName as the 'FeatureType' in the request?\"";
-
-            //Act
-            ApiResponse apiResponse = ProcessApiRequest.ProcessPutRequest(apiRequest);
-
-            //Assert
-            Assert.AreEqual((int)HttpStatusCode.BadRequest, apiResponse.HttpStatusCode);
-            Assert.AreEqual(expectedJsonBody, apiResponse.Body);
-        }
-
-        [Test]
         public void ProcessPutRequestSetsHttpStatusCodeTo400AndReturnsGenericErrorMessageInResponseBodyIfPutRequestBodyContainsAJsonArrayOfFeatureSwitches()
         {
             //Arrange

--- a/Femah.Core.Tests/WhenProcessingPutRequests.cs
+++ b/Femah.Core.Tests/WhenProcessingPutRequests.cs
@@ -10,6 +10,27 @@ namespace Femah.Core.Tests
     public class WhenProcessingPutRequests
     {
         [Test]
+        public void GivenRequestContainsInvalidProperty_ThenHttp400AndGenericErrorMessageBodyIsReturned()
+        {
+            //Arrange
+            const string invalidIsEnabledProperty = "NotValidBoolean";
+            var json = string.Format("{{\"IsEnabled\":{0},\"Name\":\"TestFeatureSwitch1\",\"FeatureType\":\"Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"}}", invalidIsEnabledProperty);
+
+            var apiRequest = new PutApiRequestFactory().WithParameterName("TestFeatureSwitch")
+                                    .WithBody(json).Build(); 
+
+            //TODO: I'd like this to be a more specific error with regards to formatting
+            const string expectedJsonBody = "\"Error: Unable to deserialise the request body.  Either the JSON is invalid or the supplied 'FeatureType' value is incorrect, have you used the AssemblyQualifiedName as the 'FeatureType' in the request?\"";
+
+            //Act
+            var apiResponse = ProcessApiRequest.ProcessPutRequest(apiRequest);
+
+            //Assert
+            apiResponse.HttpStatusCode.ShouldBe((int)HttpStatusCode.BadRequest);
+            apiResponse.Body.ShouldBe(expectedJsonBody);
+        }
+
+        [Test]
         public void GivenRequestContainsInvalidFeatureSwitchType_ThenHttp400AndGenericErrorMessageBodyIsReturned()
         {
             //Arrange

--- a/Femah.Core.Tests/WhenProcessingPutRequests.cs
+++ b/Femah.Core.Tests/WhenProcessingPutRequests.cs
@@ -10,6 +10,24 @@ namespace Femah.Core.Tests
     public class WhenProcessingPutRequests
     {
         [Test]
+        public void GivenRequestContainsInvalidJson_ThenHttp400AndGenericErrorMessageBodyIsReturned()
+        {
+            //Arrange
+            var apiRequest = new PutApiRequestFactory().WithParameterName("TestFeatureSwitch")
+                .WithBody("This is not JSON").Build();
+
+            //TODO: I'd like this to be a more specific error with regards to formatting
+            const string expectedJsonBody = "\"Error: Unable to deserialise the request body.  Either the JSON is invalid or the supplied 'FeatureType' value is incorrect, have you used the AssemblyQualifiedName as the 'FeatureType' in the request?\"";
+
+            //Act
+            var apiResponse = ProcessApiRequest.ProcessPutRequest(apiRequest);
+
+            //Assert
+            apiResponse.HttpStatusCode.ShouldBe((int)HttpStatusCode.BadRequest);
+            apiResponse.Body.ShouldBe(expectedJsonBody);
+        }
+
+        [Test]
         public void GivenRequestContainsInvalidProperty_ThenHttp400AndGenericErrorMessageBodyIsReturned()
         {
             //Arrange


### PR DESCRIPTION
Moved invalid property test and invalid json body test to WhenProcessingPutRequests
