### PR TITLE
#74 - Create Symbol package to support debugging of femah.

### DIFF
--- a/Femah.Core/Femah.Core.nuspec
+++ b/Femah.Core/Femah.Core.nuspec
@@ -18,6 +18,8 @@
     </dependencies>
   </metadata>
   <files>
+	<file src="BuildOutput\**\Femah.Core.pdb" target="\lib\Net35"/>
 	<file src="BuildOutput\**\Femah.Core.dll" target="\lib\Net35"/>
+	<file src="**\*.cs" target="src" />
   </files>
 </package>

--- a/Start-Build.psm1
+++ b/Start-Build.psm1
@@ -88,13 +88,13 @@ function Invoke-Compile{
 						Invoke-NUnitTestsForProject -projectPath "\Femah.Core.Tests\BuildOutput\Femah.Core.Tests.dll"
 						Remove-Module Invoke-NUnitTestsForProject
 						
-						#Create NuGet package
+						#Create NuGet and Symbol Package
 						$versionLabels = $assemblyInformationalVersion.Split(".")
 						$nuGetPackageVersion = $versionLabels[0] + "." + $versionLabels[1] + "." + $versionLabels[2] + "-beta" 
 						
 						Write-Host "Will use version: $nuGetPackageVersion to build NuGet package"
 						Import-Module "$baseModulePath\New-NuGetPackage.psm1"
-						New-NuGetPackage -versionNumber $nuGetPackageVersion -specFilePath "Femah.Core\Femah.Core.nuspec"
+						New-NuGetPackage -versionNumber $nuGetPackageVersion -specFilePath "Femah.Core\Femah.Core.nuspec" -includeSymbolPackage
 						Remove-Module New-NuGetPackage
 						
 					}

--- a/lib/powershell/modules/New-NuGetPackage.psm1
+++ b/lib/powershell/modules/New-NuGetPackage.psm1
@@ -37,7 +37,11 @@ function New-NuGetPackage{
 			[Parameter(
 				Position = 2,
 				Mandatory = $False )]
-				[string]$nuGetPath				
+				[string]$nuGetPath,
+			[Parameter(
+				Position = 3,
+				Mandatory = $False )]
+				[switch]$includeSymbolPackage					
 			)
 	Begin {
 			$DebugPreference = "Continue"
@@ -59,7 +63,14 @@ function New-NuGetPackage{
 					if ((Test-Path -Path "$basePath\BuildOutput") -eq $True) { Remove-Item -Path "$basePath\BuildOutput" -Force	-Recurse}
 					New-Item -ItemType directory -Path "$basePath\BuildOutput" -force
 					
-					& $nuGetPath pack $specFilePath -Version $versionNumber -OutputDirectory "BuildOutput"
+					if ($includeSymbolPackage)
+					{
+						& $nuGetPath pack $specFilePath -Version $versionNumber -OutputDirectory "BuildOutput" -Symbols
+					}
+					else
+					{
+						& $nuGetPath pack $specFilePath -Version $versionNumber -OutputDirectory "BuildOutput"	
+					}
 				}
 				catch [Exception] {
 					throw "Error executing NuGet Pack for supplied spec file: $specFilePath using NuGet from: $nuGetPath `r`n $_.Exception.ToString()"


### PR DESCRIPTION
. Modified build and nuspec to generate a Femah.Core.x.x.x-beta.symbols.nupkg package during the commit build. The existing TeamCity NuGet Push should hopefully publish the symbol package to symbolsource.org automatically.
