### PR TITLE
#69 - API always returns 304 as response from PUT request

### DIFF
--- a/Femah.Core.Tests/Femah.Core.Tests.csproj
+++ b/Femah.Core.Tests/Femah.Core.Tests.csproj
@@ -57,6 +57,7 @@
     <Compile Include="FemahApiRequestTests.cs" />
     <Compile Include="FemahApiTests.cs" />
     <Compile Include="FemahTests.cs" />
+    <Compile Include="InProcProviderTests.cs" />
     <Compile Include="InvalidRequestTestData.cs" />
     <Compile Include="PercentageFeatureSwitchTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -320,7 +320,7 @@ namespace Femah.Core.Tests
         }
         
         [Test]
-        [Ignore("We are now testing this in the ApiResponseBuilder(), keep this as an integration test maybe?")]
+        //[Ignore("We are now testing this in the ApiResponseBuilder(), keep this as an integration test maybe?")]
         public void ProcessPutRequestSetsHttpStatusCodeTo304AndReturnsAccurateErrorMessageInResponseBodyIfPutRequestBodyIsValidJsonButFeatureSwitchHasNoChanges()
         {
             //Arrange
@@ -361,6 +361,48 @@ namespace Femah.Core.Tests
             Assert.AreEqual(jsonRequestAndResponse, apiResponse.Body);
         }
 
+
+        [Test]
+        //[Ignore("We are now testing this in the ApiResponseBuilder(), keep this as an integration test maybe?")]
+        public void ProcessPutRequestSetsHttpStatusCodeTo200AndReturnsUpdatedEntity()
+        {
+            //Arrange
+            const string validFeatureType = "Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null";
+            string jsonRequestAndResponse = string.Format(
+                    "{{\"IsEnabled\":true,\"Name\":\"TestFeatureSwitch1\",\"FeatureType\":\"{0}\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"}}",
+                    validFeatureType);
+
+            var apiRequest = new ApiRequest
+            {
+                HttpMethod = "PUT",
+                Service = ApiRequest.ApiService.featureswitches,
+                Parameter = "TestFeatureSwitch",
+                Body = jsonRequestAndResponse
+            };
+
+            var featureSwitch = new SimpleFeatureSwitch
+            {
+                Name = "TestFeatureSwitch1",
+                IsEnabled = false,
+                FeatureType = validFeatureType
+            };
+
+            var providerMock = new Mock<IFeatureSwitchProvider>();
+            providerMock.Setup(p => p.Get("TestFeatureSwitch1"))
+                .Returns(featureSwitch);
+
+            Femah.Configure()
+                .FeatureSwitchEnum(typeof(FeatureSwitches))
+                .Provider(providerMock.Object)
+                .Initialise();
+
+            //Act
+            ApiResponse apiResponse = ProcessApiRequest.ProcessPutRequest(apiRequest);
+
+            //Assert
+            Assert.AreEqual((int)HttpStatusCode.OK, apiResponse.HttpStatusCode);
+            Assert.AreEqual(jsonRequestAndResponse, apiResponse.Body);
+        }
         #endregion
 
         #region General API (GET methods)

--- a/Femah.Core.Tests/InProcProviderTests.cs
+++ b/Femah.Core.Tests/InProcProviderTests.cs
@@ -1,0 +1,43 @@
+﻿using Femah.Core.Providers;
+using NUnit.Framework;
+
+namespace Femah.Core.Tests
+{
+    public class InProcProviderTests
+    {
+        public enum FeatureSwitches
+        {
+            SomeNewFeature = 1
+        }
+
+        public class TheGetMethod
+        {
+            
+            [SetUp]
+            public void Initialize()
+            {
+            }
+
+            [Test]
+            public void FeatureTypeIsFullyQualifiedAssemblyName()
+            {
+                //Arrange
+                var inProcProvider = new InProcProvider();
+                const string expectedFullyQualifiedFeatureType = "Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null";
+
+                //Act
+                Femah.Configure()
+                    .FeatureSwitchEnum(typeof(FeatureSwitches))
+                    .Initialise();
+
+                var featureSwitch = inProcProvider.Get("SomeNewFeature");
+
+                //Assert
+                Assert.AreEqual(expectedFullyQualifiedFeatureType, featureSwitch.FeatureType);
+                
+
+            }
+        }
+
+    }
+}

--- a/Femah.Core/Api/ApiResponseBuilder.cs
+++ b/Femah.Core/Api/ApiResponseBuilder.cs
@@ -109,7 +109,7 @@ namespace Femah.Core.Api
                 
                 //Updated and desired FeatureSwitch states DO match, return to client
                 if (updatedFeatureSwitchState.Equals(desiredfeatureSwitchState))
-                    return SetResponseProperties(currentFeatureSwitchState.ToJson(), HttpStatusCode.OK);
+                    return SetResponseProperties(updatedFeatureSwitchState.ToJson(), HttpStatusCode.OK);
 
                 //Updated and desired FeatureSwitch states do NOT match, roll back change
                 //This is probably not the best way to do this, TODO: maybe make all changes within a transaction?

--- a/Femah.Core/Femah.cs
+++ b/Femah.Core/Femah.cs
@@ -145,7 +145,7 @@ namespace Femah.Core
             {
                 newFeatureSwitch.Name = featureSwitch.Name;
                 newFeatureSwitch.IsEnabled = featureSwitch.IsEnabled;
-                newFeatureSwitch.FeatureType = featureSwitch.GetType().Name;
+                newFeatureSwitch.FeatureType = featureSwitch.GetType().AssemblyQualifiedName;
             }
 
             // Save as the new type of feature switch.

--- a/Femah.Core/Providers/InProcProvider.cs
+++ b/Femah.Core/Providers/InProcProvider.cs
@@ -23,7 +23,7 @@ namespace Femah.Core.Providers
 
             foreach (var featureSwitch in featureSwitches)
             {
-                _featureSwitches.Add(new SimpleFeatureSwitch { Name = featureSwitch, IsEnabled = false, FeatureType = featureSwitch.GetType().Name});
+                _featureSwitches.Add(new SimpleFeatureSwitch { Name = featureSwitch, IsEnabled = false, FeatureType = typeof(SimpleFeatureSwitch).AssemblyQualifiedName });
             }
         }
 


### PR DESCRIPTION
Modified the InProcProvider initialisation to set a fully qualified assembly name, made similar change to Femah.Core.Femah.SetSwitchType
@hotstone can you take a look please?
