### PR TITLE
#48 - Add release notes to Femah.Core NuGet package when publishing.

### DIFF
--- a/Start-FemahBuildDefault.ps1
+++ b/Start-FemahBuildDefault.ps1
@@ -45,9 +45,8 @@ Task Publish-Femah -depends Update-GithubReleaseTagName {
 }
 
 #*================================================================================================
-#* Purpose: Updates the tag_name of the matching Release from Github for the current [major].[minor] 
-#* build with the full build number of the current build, i.e. v[major].[minor].[counter] that we
-#* intend to publish to Nuget.org.
+#* Purpose: Updates the tag_name of the matching Release in Github that we intend to publish to 
+#* Nuget.org with the current build number, i.e. v[major].[minor].[counter], e.g. v0.1.57-beta
 #*================================================================================================
 Task Update-GithubReleaseTagName -depends Get-GithubRelease {
 

--- a/lib/powershell/modules/Invoke-GithubApiRequest.psm1
+++ b/lib/powershell/modules/Invoke-GithubApiRequest.psm1
@@ -1,0 +1,66 @@
+function Invoke-GithubApiRequest{
+<#
+ 
+.SYNOPSIS
+    Given HTTP parameters and credentials will invoke an HTTP request to the Github API.
+.DESCRIPTION
+    Given HTTP parameters and credentials will invoke a HTTP request to the Github API using Invoke-RestMethod.
+
+.NOTES
+	Requirements: Copy this module to any location found in $env:PSModulePath
+.PARAMETER uri
+	Required. The complete Uri to use in the HTTP request.
+.PARAMETER method
+	Required. The HTTP method to use in the HTTP request, valid options are GET, PUT 
+.PARAMETER githubToken
+	Required. An active Github API token to authenticate against the Github API with.
+.EXAMPLE 
+	Import-Module Invoke-GithubApiRequest
+	Import the module
+.EXAMPLE	
+	Get-Command -Module Invoke-GithubApiRequest
+	List available functions
+.EXAMPLE
+	Invoke-GithubApiRequest -uri "https://api.github.com/repos/lloydstone/femah/releases" -method GET -githubToken "c2e14cc45b7977286d576b0e4d8bb5ff2767364a"
+	Execute the module
+#>
+	[cmdletbinding()]
+		Param(
+			[Parameter(
+				Position = 0,
+				Mandatory = $True )]
+				[string]$uri,		
+			[Parameter(
+				Position = 1,
+				Mandatory = $True )]
+				[string]$method,
+			[Parameter(
+				Position = 2,
+				Mandatory = $True )]
+				[string]$githubToken				
+			)
+
+	Begin {
+			$DebugPreference = "Continue"
+		}	
+	Process {
+				Try 
+				{
+					
+					$params = @{
+					  Uri = $uri;
+					  Method = $method;
+					  Headers = @{
+						Authorization = 'Basic ' + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("$($githubToken):x-oauth-basic"));
+						UserAgent = 'User-Agent: femah-deployment-pipeline'
+					  }
+					  ContentType = 'application/json';
+					}  
+					
+					return Invoke-RestMethod @params
+				}
+				catch [Exception] {
+					throw "Error executing request to Github API: `r`n $_"
+				}
+		}
+}

--- a/lib/powershell/modules/Invoke-GithubApiRequest.psm1
+++ b/lib/powershell/modules/Invoke-GithubApiRequest.psm1
@@ -11,9 +11,11 @@ function Invoke-GithubApiRequest{
 .PARAMETER uri
 	Required. The complete Uri to use in the HTTP request.
 .PARAMETER method
-	Required. The HTTP method to use in the HTTP request, valid options are GET, PUT 
+	Required. The HTTP method to use in the HTTP request, valid options are 'GET' or 'POST'
 .PARAMETER githubToken
 	Required. An active Github API token to authenticate against the Github API with.
+.PARAMETER body
+	Optional. A valid and escaped JSON string body to pass with the request.
 .EXAMPLE 
 	Import-Module Invoke-GithubApiRequest
 	Import the module
@@ -37,7 +39,11 @@ function Invoke-GithubApiRequest{
 			[Parameter(
 				Position = 2,
 				Mandatory = $True )]
-				[string]$githubToken				
+				[string]$githubToken,
+			[Parameter(
+				Position = 3,
+				Mandatory = $False )]
+				[string]$body				
 			)
 
 	Begin {
@@ -55,6 +61,7 @@ function Invoke-GithubApiRequest{
 						UserAgent = 'User-Agent: femah-deployment-pipeline'
 					  }
 					  ContentType = 'application/json';
+					  Body = if ($body -ne "") { $body };
 					}  
 					
 					return Invoke-RestMethod @params


### PR DESCRIPTION
Began implementation of the 'Publish' phase of the deployment pipeline.
- Added psake tasks and a Powershell module to update the Github.com release 'tag_name' and 'draft' (published) status for the current build, using the Github API.  This provides the ability to fully automate the 'Publish' phase of the deployment pipeline that publishes the Nuget and Symbol packages to nuget.org and symbolsource.org respectively.
