### PR TITLE
#48 - Add release notes to Femah.Core NuGet package when publishing.

### DIFF
--- a/Start-FemahBuild.ps1
+++ b/Start-FemahBuild.ps1
@@ -24,7 +24,7 @@
 #*==========================================================================================
 #* SCRIPT BODY
 #*==========================================================================================
-param([string]$task = "Invoke-Commit", [string]$msbuildPath = "C:\Windows\Microsoft.NET\Framework\v4.0.30319\msbuild.exe", [string]$configMode = "Debug", [string]$buildCounter = "0", [string]$gitPath = "", [switch]$publishToLive, [string]$githubApiKey = "", [string]$nugetApiKey = "")
+param([string]$task = "Invoke-Commit", [string]$msbuildPath = "C:\Windows\Microsoft.NET\Framework\v4.0.30319\msbuild.exe", [string]$configMode = "Release", [string]$buildCounter = "0", [string]$gitPath = "", [switch]$publishToLive, [string]$githubApiKey = "", [string]$nugetApiKey = "")
 
 Write-Host "Using the following parameter values (sensible defaults used where parameter not supplied)"
 Write-Host "task: $task"
@@ -36,7 +36,8 @@ Write-Host "publishToLive: $publishToLive"
 Write-Host "githubApiKey: $githubApiKey"
 Write-Host "nugetApiKey: $nugetApiKey"
 
-Import-Module '.\lib\psake.4.3.1.0\tools\psake.psm1'; 
+$basePath = Resolve-Path .
+Import-Module "$basePath\lib\psake.4.3.1.0\tools\psake.psm1" 
 #$psake
 #$psake.use_exit_on_error = $true
 Invoke-psake .\Start-FemahBuildDefault.ps1 -t $task -framework '4.0' -parameters @{"p1"=$msbuildPath;"p2"=$configMode;"p3"=$buildCounter;"p4"=$gitPath;"p5"=$publishToLive;"p6"=$githubApiKey;"p7"=$nugetApiKey} 

--- a/Start-FemahBuildDefault.ps1
+++ b/Start-FemahBuildDefault.ps1
@@ -174,14 +174,14 @@ Task Invoke-Commit -depends Invoke-Compile, Invoke-UnitTests, Update-ReleaseNote
 #*================================================================================================
 Task Invoke-Compile -depends Invoke-HardcoreClean, Set-VersionNumber {
 
-	if($configMode -ne "Debug" -or $configMode -ne "Release")
+	if(($configMode -ne "Debug") -and ($configMode -ne "Release"))
 	{ 
-		Write-Host "Unknown configMode $configMode supplied.  Valid values are 'Debug' or 'Release', changing to default 'Release'"
+		Write-Host "Unknown configMode ""$configMode"" supplied.  Valid values are ""Debug"" or ""Release"", changing to default 'Release'"
 		$configMode = "Release"
 	}
 	$solutionFile = "Femah.sln"
 	Write-Host "Building ""$solutionFile"" in ""$configMode"" mode."
-	exec { & $msbuildPath $solutionFile /t:ReBuild /t:Clean /p:Configuration=$configMode /p:PlatformTarget=AnyCPU /m}
+	exec { & $msbuildPath $solutionFile /t:ReBuild /t:Clean /p:Configuration=$configMode /p:PlatformTarget=AnyCPU /m }
 }
 
 #*================================================================================================


### PR DESCRIPTION
- Defaulted '-configMode' in build scripts to 'Release'
- Modified how psake module is loaded as I have a feeling it is causing TeamCity to trip up in the Publish-Femah build with the error "Import-Module : The specified module '.\lib\psake.4.3.1.0\tools\psake.psm1' [00:59:02]was not loaded because no valid module file was found in any module directory."
