### PR TITLE
#48 - Add release notes to Femah.Core NuGet package when publishing.

### DIFF
--- a/Start-FemahBuild.ps1
+++ b/Start-FemahBuild.ps1
@@ -24,7 +24,7 @@
 #*==========================================================================================
 #* SCRIPT BODY
 #*==========================================================================================
-param([string]$task = "Invoke-Commit", [string]$msbuildPath = "C:\Windows\Microsoft.NET\Framework\v4.0.30319\msbuild.exe", [string]$configMode = "Release", [string]$buildCounter = "0", [string]$gitPath = "", [switch]$publishToLive, [string]$githubApiKey = "", [string]$nugetApiKey = "")
+param([string]$task = "Invoke-Commit", [string]$msbuildPath = "C:\Windows\Microsoft.NET\Framework\v4.0.30319\msbuild.exe", [string]$configMode = "Release", [string]$buildCounter = "0", [string]$gitPath = "", [bool]$publishToLive = $False, [string]$githubApiKey = "", [string]$nugetApiKey = "")
 
 Write-Host "Using the following parameter values (sensible defaults used where parameter not supplied)"
 Write-Host "task: $task"

--- a/Start-FemahBuildDefault.ps1
+++ b/Start-FemahBuildDefault.ps1
@@ -67,18 +67,6 @@ Task Check-PublishToLiveSwitches {
 }
 
 #*================================================================================================
-#* Purpose: Checks whether we have explicitly supplied the -publishToLive switch, hopefully helping
-#* to avoid accidently pushing to nuget.org
-#*================================================================================================
-Task Check-PublishToLiveSwitch {
-
-	if ($publishToLive -eq $False) {
-		throw "Supply the -publishToLive switch to confirm execution of the Publish-Femah task."
-		return
-	}
-}
-
-#*================================================================================================
 #* Purpose: Updates the status of the matching Release in Github that we intend to publish to 
 #* Nuget.org to be 'Published'.
 #*================================================================================================


### PR DESCRIPTION
- Modifying the -publishToLive build switch to take a boolean value to help us add manual confirmation during the TeamCity build execution.
