### PR TITLE
#52 - Refactor unit test layout and naming to be more BDD orientated

### DIFF
--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -294,31 +294,6 @@ namespace Femah.Core.Tests
 
         #region ProcessApiRequest
         [Test]
-        public void ProcessPutRequestSetsHttpStatusCodeTo400AndReturnsGenericErrorMessageInResponseBodyIfPutRequestBodyContainsAJsonArrayOfFeatureSwitches()
-        {
-            //Arrange
-            const string validFeatureType = "Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null";
-
-            var apiRequest = new ApiRequest
-            {
-                HttpMethod = "PUT",
-                Service = ApiRequest.ApiService.featureswitches,
-                Parameter = "TestFeatureSwitch",
-                Body = string.Format("{{\"IsEnabled\":true,\"Name\":\"TestFeatureSwitch1\",\"FeatureType\":\"{0}\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"}},{{\"IsEnabled\":true,\"Name\":\"TestFeatureSwitch2\",\"FeatureType\":\"{0}\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"}}", validFeatureType)
-            };
-
-            //TODO: I'd like this to be a more specific error with regards to formatting
-            const string expectedJsonBody = "\"Error: Unable to deserialise the request body.  Either the JSON is invalid or the supplied 'FeatureType' value is incorrect, have you used the AssemblyQualifiedName as the 'FeatureType' in the request?\"";
-
-            //Act
-            ApiResponse apiResponse = ProcessApiRequest.ProcessPutRequest(apiRequest);
-
-            //Assert
-            Assert.AreEqual((int)HttpStatusCode.BadRequest, apiResponse.HttpStatusCode);
-            Assert.AreEqual(expectedJsonBody, apiResponse.Body);
-        }
-        
-        [Test]
         //[Ignore("We are now testing this in the ApiResponseBuilder(), keep this as an integration test maybe?")]
         public void ProcessPutRequestSetsHttpStatusCodeTo304IfPutRequestBodyIsValidJsonButFeatureSwitchHasNoChanges()
         {

--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
-using System.Text;
 using System.Web;
 using Femah.Core.Api;
 using Femah.Core.FeatureSwitchTypes;
@@ -359,49 +358,6 @@ namespace Femah.Core.Tests
             //Assert
             Assert.AreEqual((int)HttpStatusCode.NotModified, apiResponse.HttpStatusCode);
             Assert.AreEqual(string.Empty, apiResponse.Body);
-        }
-
-
-        [Test]
-        //[Ignore("We are now testing this in the ApiResponseBuilder(), keep this as an integration test maybe?")]
-        public void ProcessPutRequestSetsHttpStatusCodeTo200AndReturnsUpdatedEntity()
-        {
-            //Arrange
-            const string validFeatureType = "Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null";
-            string jsonRequestAndResponse = string.Format(
-                    "{{\"IsEnabled\":true,\"Name\":\"TestFeatureSwitch1\",\"FeatureType\":\"{0}\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"}}",
-                    validFeatureType);
-
-            var apiRequest = new ApiRequest
-            {
-                HttpMethod = "PUT",
-                Service = ApiRequest.ApiService.featureswitches,
-                Parameter = "TestFeatureSwitch",
-                Body = jsonRequestAndResponse
-            };
-
-            var featureSwitch = new SimpleFeatureSwitch
-            {
-                Name = "TestFeatureSwitch1",
-                IsEnabled = false,
-                FeatureType = validFeatureType
-            };
-
-            var providerMock = new Mock<IFeatureSwitchProvider>();
-            providerMock.Setup(p => p.Get("TestFeatureSwitch1"))
-                .Returns(featureSwitch);
-
-            Femah.Configure()
-                .FeatureSwitchEnum(typeof(FeatureSwitches))
-                .Provider(providerMock.Object)
-                .Initialise();
-
-            //Act
-            ApiResponse apiResponse = ProcessApiRequest.ProcessPutRequest(apiRequest);
-
-            //Assert
-            Assert.AreEqual((int)HttpStatusCode.OK, apiResponse.HttpStatusCode);
-            Assert.AreEqual(jsonRequestAndResponse, apiResponse.Body);
         }
         #endregion
 

--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -292,50 +292,6 @@ namespace Femah.Core.Tests
 
         #endregion
 
-        #region ProcessApiRequest
-        [Test]
-        //[Ignore("We are now testing this in the ApiResponseBuilder(), keep this as an integration test maybe?")]
-        public void ProcessPutRequestSetsHttpStatusCodeTo304IfPutRequestBodyIsValidJsonButFeatureSwitchHasNoChanges()
-        {
-            //Arrange
-            const string validFeatureType = "Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null";
-            string jsonRequestAndResponse = string.Format(
-                    "{{\"IsEnabled\":true,\"Name\":\"TestFeatureSwitch1\",\"FeatureType\":\"{0}\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"}}",
-                    validFeatureType);
-
-            var apiRequest = new ApiRequest
-            {
-                HttpMethod = "PUT",
-                Service = ApiRequest.ApiService.featureswitches,
-                Parameter = "TestFeatureSwitch",
-                Body = jsonRequestAndResponse
-            };
-
-            var featureSwitch = new SimpleFeatureSwitch
-            {
-                    Name = "TestFeatureSwitch1",
-                    IsEnabled = true,
-                    FeatureType = validFeatureType
-            };
-
-            var providerMock = new Mock<IFeatureSwitchProvider>();
-            providerMock.Setup(p => p.Get("TestFeatureSwitch1"))
-                .Returns(featureSwitch);
-
-            Femah.Configure()
-                .FeatureSwitchEnum(typeof(FeatureSwitches))
-                .Provider(providerMock.Object)
-                .Initialise();
-
-            //Act
-            ApiResponse apiResponse = ProcessApiRequest.ProcessPutRequest(apiRequest);
-
-            //Assert
-            Assert.AreEqual((int)HttpStatusCode.NotModified, apiResponse.HttpStatusCode);
-            Assert.AreEqual(string.Empty, apiResponse.Body);
-        }
-        #endregion
-
         #region General API (GET methods)
 
         

--- a/Femah.Core.Tests/ProcessApiRequestTests.cs
+++ b/Femah.Core.Tests/ProcessApiRequestTests.cs
@@ -110,8 +110,8 @@ namespace Femah.Core.Tests
                 var apiResponse = ProcessApiRequest.ProcessPutRequest(apiRequest);
 
                 //Assert
-                Assert.AreEqual((int) HttpStatusCode.MethodNotAllowed, apiResponse.HttpStatusCode);
-                Assert.AreEqual(expectedJsonBody, apiResponse.Body);
+                apiResponse.HttpStatusCode.ShouldBe((int) HttpStatusCode.MethodNotAllowed);
+                apiResponse.Body.ShouldBe(expectedJsonBody);
             }
 
             [Test]
@@ -152,8 +152,8 @@ namespace Femah.Core.Tests
                 var apiResponse = ProcessApiRequest.ProcessPutRequest(apiRequest);
 
                 //Assert
-                Assert.AreEqual((int) HttpStatusCode.OK, apiResponse.HttpStatusCode);
-                Assert.AreEqual(jsonRequestAndResponse, apiResponse.Body);
+                apiResponse.HttpStatusCode.ShouldBe((int)HttpStatusCode.OK);
+                apiResponse.Body.ShouldBe(jsonRequestAndResponse);
             }
 
             private static Mock<IFeatureSwitchProvider> BuildSimpleFeatureSwitch(string validFeatureType, bool enabled = false)

--- a/Femah.Core.Tests/ProcessApiRequestTests.cs
+++ b/Femah.Core.Tests/ProcessApiRequestTests.cs
@@ -12,7 +12,28 @@ namespace Femah.Core.Tests
         public class TheProcessPutRequestMethod
         {
             private const string ValidFeatureType = "Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null";
+
+            [Test]
+            public void ReturnsGenericErrorMessageInResponseBodyAndSetsHttpStatusCodeTo400_IfPutRequestBodyContainsAJsonArrayOfFeatureSwitches()
+            {
+                //Arrange
+                var requestBody = string.Format("{{\"IsEnabled\":true,\"Name\":\"TestFeatureSwitch1\",\"FeatureType\":\"{0}\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"}},{{\"IsEnabled\":true,\"Name\":\"TestFeatureSwitch2\",\"FeatureType\":\"{0}\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"}}", ValidFeatureType);
+                const string expectedJsonBody = "\"Error: Unable to deserialise the request body.  Either the JSON is invalid or the supplied 'FeatureType' value is incorrect, have you used the AssemblyQualifiedName as the 'FeatureType' in the request?\"";
+                //TODO: I'd like this to be a more specific error with regards to formatting
                 
+                var apiRequest = new PutApiRequestFactory()
+                    .ForServiceType(ApiRequest.ApiService.featureswitches)
+                    .WithParameterName("TestFeatureSwitch")
+                    .WithBody(requestBody).Build();
+
+                //Act
+                var apiResponse = ProcessApiRequest.ProcessPutRequest(apiRequest);
+
+                //Assert
+                apiResponse.HttpStatusCode.ShouldBe((int)HttpStatusCode.BadRequest);
+                apiResponse.Body.ShouldBe(expectedJsonBody);
+            }
+    
             [Test]
             public void ReturnsUpdatedEntityAndSetsHttpStatusCodeTo200_IfRequestIsValid()
             {


### PR DESCRIPTION
Moved the re-enabled tests for the ProcessApiRequest class over to the ProcessApiRequestTests file from FemahApiTests
