### PR TITLE
#52 - Refactor unit test layout and naming to be more BDD orientated

### DIFF
--- a/Femah.Core.Tests/ApiResponseBuilderTests.cs
+++ b/Femah.Core.Tests/ApiResponseBuilderTests.cs
@@ -11,18 +11,50 @@ namespace Femah.Core.Tests
     {
         public class TheCreateWithUpdatedFeatureSwitchMethod
         {
-            private const string ValidFeatureType = "Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null";
+            private const string ValidSimpleFeatureType = "Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null";
+            private const string ValidPercentageFeatureType = "Femah.Core.FeatureSwitchTypes.PercentageFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null";
 
+            [Test]
+            public void ReturnsHttpStatusCodeTo200AndDesiredFeatureSwitchState_IfPutRequestIncludesFeatureSwitchChangesToCustomParameters()
+            {
+                //Arrange
+                const string jsonResponse = "{\"PercentageOn\":75,\"Description\":\"A simple feature switch that is on for a set percentage of users. The state of the switch is persisted in the user's cookies.If no cookie exists the state is chosen at random (weighted according to the percentage), and then stored in a cookie.\",\"ConfigurationInstructions\":\"Set PercentageOn to the percentage of users who should see this feature. Eg. 10 means the feature is on for 10% of users.\",\"IsEnabled\":true,\"Name\":\"TestFeatureSwitch1\",\"FeatureType\":\"Femah.Core.FeatureSwitchTypes.PercentageFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null\"}";
+
+                var currentFeatureSwitchState = BuildPercentageFeatureSwitch(50);
+                var desiredFeatureSwitchState = BuildPercentageFeatureSwitch(75);
+
+                var providerMock = new Mock<IFeatureSwitchProvider>();
+                providerMock.Setup(p => p.Get("TestFeatureSwitch1"))
+                    .Returns(currentFeatureSwitchState);
+
+                Femah.Configure()
+                    .FeatureSwitchEnum(typeof(FeatureSwitches))
+                    .Provider(providerMock.Object)
+                    .Initialise();
+
+                //Act
+                ApiResponse apiResponse;
+                using (var apiResponseBuilder = new ApiResponseBuilder())
+                {
+                    apiResponse = apiResponseBuilder.CreateWithUpdatedFeatureSwitch(desiredFeatureSwitchState);
+                }
+
+                //Assert
+                apiResponse.HttpStatusCode.ShouldBe((int)HttpStatusCode.OK);
+                apiResponse.Body.ShouldBe(jsonResponse);
+        
+            }
+            
             [Test]
             public void ReturnsHttpStatusCodeTo200AndDesiredFeatureSwitchState_IfPutRequestIncludesFeatureSwitchChangesToIsEnabledState()
             {
                 //Arrange
                 string jsonRequestAndResponse = string.Format(
                         "{{\"IsEnabled\":false,\"Name\":\"TestFeatureSwitch1\",\"FeatureType\":\"{0}\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"}}",
-                       ValidFeatureType);
+                       ValidSimpleFeatureType);
 
-                var currentFeatureSwitchState = BuildFeatureSwitch();
-                var desiredFeatureSwitchState = BuildFeatureSwitch(false);
+                var currentFeatureSwitchState = BuildSimpleFeatureSwitch();
+                var desiredFeatureSwitchState = BuildSimpleFeatureSwitch(false);
 
                 var providerMock = new Mock<IFeatureSwitchProvider>();
                 providerMock.Setup(p => p.Get("TestFeatureSwitch1"))
@@ -49,7 +81,7 @@ namespace Femah.Core.Tests
             public void ReturnsHttpStatusCodeTo304_IfPutRequestBodyIsValidJsonButFeatureSwitchHasNoChanges()
             {
                 //Arrange
-                var featureSwitch = BuildFeatureSwitch();
+                var featureSwitch = BuildSimpleFeatureSwitch();
 
                 var providerMock = new Mock<IFeatureSwitchProvider>();
                 providerMock.Setup(p => p.Get("TestFeatureSwitch1"))
@@ -72,13 +104,24 @@ namespace Femah.Core.Tests
                 apiResponse.Body.ShouldBe(string.Empty);
             }
 
-            private static SimpleFeatureSwitch BuildFeatureSwitch(bool enabled = true)
+            private static PercentageFeatureSwitch BuildPercentageFeatureSwitch(int percentage, bool enabled = true)
+            {
+                return new PercentageFeatureSwitch
+                {
+                    Name = "TestFeatureSwitch1",
+                    FeatureType = ValidPercentageFeatureType,
+                    IsEnabled = enabled,
+                    PercentageOn = percentage
+                };
+            }
+
+            private static SimpleFeatureSwitch BuildSimpleFeatureSwitch(bool enabled = true)
             {
                 return new SimpleFeatureSwitch
                 {
                     Name = "TestFeatureSwitch1",
                     IsEnabled = enabled,
-                    FeatureType = ValidFeatureType,
+                    FeatureType = ValidSimpleFeatureType,
                 };
             }
         }

--- a/Femah.Core.Tests/ApiResponseBuilderTests.cs
+++ b/Femah.Core.Tests/ApiResponseBuilderTests.cs
@@ -104,6 +104,43 @@ namespace Femah.Core.Tests
                 apiResponse.Body.ShouldBe(string.Empty);
             }
 
+            [Test]
+            [Ignore("Can't currently mock Femah easily, seeing as it's both sealed and the methods we're interested in are internal static, thoughts?")]
+            public void CallsUpdateOnFeatureTypeStateIsEnabledStateAndAttributes()
+            {
+                //Arrange
+                //const string jsonResponse = "{\"PercentageOn\":75,\"Description\":\"A simple feature switch that is on for a set percentage of users. The state of the switch is persisted in the user's cookies.If no cookie exists the state is chosen at random (weighted according to the percentage), and then stored in a cookie.\",\"ConfigurationInstructions\":\"Set PercentageOn to the percentage of users who should see this feature. Eg. 10 means the feature is on for 10% of users.\",\"IsEnabled\":true,\"Name\":\"TestFeatureSwitch1\",\"FeatureType\":\"Femah.Core.FeatureSwitchTypes.PercentageFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null\"}";
+
+                var currentFeatureSwitchState = BuildPercentageFeatureSwitch(50);
+                var desiredFeatureSwitchState  = BuildPercentageFeatureSwitch(75);
+                  
+                var providerMock = new Mock<IFeatureSwitchProvider>();
+                providerMock.Setup(p => p.Get("TestFeatureSwitch1"))
+                    .Returns(currentFeatureSwitchState);
+
+                var femahMock = new Mock<Femah>();
+                //femahMock.Setup(f => f)
+                //TODO: Can't currently mock Femah easily, seeing as it's both sealed and the methods we're interested in are internal static, thoughts?
+
+
+                Femah.Configure()
+                    .FeatureSwitchEnum(typeof(FeatureSwitches))
+                    .Provider(providerMock.Object)
+                    .Initialise();
+
+                //Act
+                ApiResponse apiResponse;
+                using (var apiResponseBuilder = new ApiResponseBuilder())
+                {
+                    apiResponse = apiResponseBuilder.CreateWithUpdatedFeatureSwitch(desiredFeatureSwitchState);
+                }
+
+                //Assert
+                //Assert.AreEqual((int)HttpStatusCode.OK, apiResponse.HttpStatusCode);
+                //Assert.AreEqual(jsonResponse, apiResponse.Body);
+
+            }
+
             private static PercentageFeatureSwitch BuildPercentageFeatureSwitch(int percentage, bool enabled = true)
             {
                 return new PercentageFeatureSwitch

--- a/Femah.Core.Tests/ApiResponseBuilderTests.cs
+++ b/Femah.Core.Tests/ApiResponseBuilderTests.cs
@@ -1,0 +1,91 @@
+using Femah.Core.Api;
+using Femah.Core.FeatureSwitchTypes;
+using Moq;
+using NUnit.Framework;
+using Shouldly;
+using System.Net;
+
+namespace Femah.Core.Tests
+{
+    public class ApiResponseBuilderTests
+    {
+        public class TheCreateWithUpdatedFeatureSwitchMethod
+        {
+            private const string ValidFeatureType = "Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null";
+
+            [Test]
+            public void ReturnsHttpStatusCodeTo200AndDesiredFeatureSwitchState_IfPutRequestIncludesFeatureSwitchChangesToIsEnabledState()
+            {
+                //Arrange
+                string jsonRequestAndResponse = string.Format(
+                        "{{\"IsEnabled\":false,\"Name\":\"TestFeatureSwitch1\",\"FeatureType\":\"{0}\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"}}",
+                       ValidFeatureType);
+
+                var currentFeatureSwitchState = BuildFeatureSwitch();
+                var desiredFeatureSwitchState = BuildFeatureSwitch(false);
+
+                var providerMock = new Mock<IFeatureSwitchProvider>();
+                providerMock.Setup(p => p.Get("TestFeatureSwitch1"))
+                    .Returns(currentFeatureSwitchState);
+
+                Femah.Configure()
+                    .FeatureSwitchEnum(typeof(FeatureSwitches))
+                    .Provider(providerMock.Object)
+                    .Initialise();
+
+                //Act
+                ApiResponse apiResponse;
+                using (var apiResponseBuilder = new ApiResponseBuilder())
+                {
+                    apiResponse = apiResponseBuilder.CreateWithUpdatedFeatureSwitch(desiredFeatureSwitchState);
+                }
+
+                //Assert
+                apiResponse.HttpStatusCode.ShouldBe((int)HttpStatusCode.OK);
+                apiResponse.Body.ShouldBe(jsonRequestAndResponse);
+            }
+
+            [Test]
+            public void ReturnsHttpStatusCodeTo304_IfPutRequestBodyIsValidJsonButFeatureSwitchHasNoChanges()
+            {
+                //Arrange
+                var featureSwitch = BuildFeatureSwitch();
+
+                var providerMock = new Mock<IFeatureSwitchProvider>();
+                providerMock.Setup(p => p.Get("TestFeatureSwitch1"))
+                    .Returns(featureSwitch);
+
+                Femah.Configure()
+                    .FeatureSwitchEnum(typeof(FemahApiTests.FeatureSwitches))
+                    .Provider(providerMock.Object)
+                    .Initialise();
+
+                //Act
+                ApiResponse apiResponse;
+                using (var apiResponseBuilder = new ApiResponseBuilder())
+                {
+                    apiResponse = apiResponseBuilder.CreateWithUpdatedFeatureSwitch(featureSwitch);
+                }
+
+                //Assert
+                apiResponse.HttpStatusCode.ShouldBe((int)HttpStatusCode.NotModified);
+                apiResponse.Body.ShouldBe(string.Empty);
+            }
+
+            private static SimpleFeatureSwitch BuildFeatureSwitch(bool enabled = true)
+            {
+                return new SimpleFeatureSwitch
+                {
+                    Name = "TestFeatureSwitch1",
+                    IsEnabled = enabled,
+                    FeatureType = ValidFeatureType,
+                };
+            }
+        }
+
+        public enum FeatureSwitches
+        {
+            SomeNewFeature = 1
+        }
+    }
+}

--- a/Femah.Core.Tests/Femah.Core.Tests.csproj
+++ b/Femah.Core.Tests/Femah.Core.Tests.csproj
@@ -54,6 +54,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ApiResponseBuilderTests.cs" />
     <Compile Include="FemahApiRequestTests.cs" />
     <Compile Include="FemahApiTests.cs" />
     <Compile Include="FemahTests.cs" />

--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -113,12 +113,6 @@ namespace Femah.Core.Tests
         
         #endregion
 
-        #region ApiResponseBuilder
-       
-        
-
-        #endregion
-
         #region ProcessApiRequest
         [Test]
         public void ProcessPutRequestSetsHttpStatusCodeTo400AndReturnsGenericErrorMessageInResponseBodyIfPutRequestBodyContainsAJsonArrayOfFeatureSwitches()

--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -115,43 +115,7 @@ namespace Femah.Core.Tests
 
         #region ApiResponseBuilder
 
-        [Test]
-        public void ApiResponseBuilderSetsHttpStatusCodeTo304IfPutRequestBodyIsValidJsonButFeatureSwitchHasNoChanges()
-        {
-            //Arrange
-            const string validFeatureType = "Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null";
-            string jsonRequestAndResponse = string.Format(
-                    "{{\"IsEnabled\":true,\"Name\":\"TestFeatureSwitch1\",\"FeatureType\":\"{0}\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"}}",
-                    validFeatureType);
-
-            var featureSwitch = new SimpleFeatureSwitch
-            {
-                Name = "TestFeatureSwitch1",
-                IsEnabled = true,
-                FeatureType = validFeatureType
-            };
-
-            var providerMock = new Mock<IFeatureSwitchProvider>();
-            providerMock.Setup(p => p.Get("TestFeatureSwitch1"))
-                .Returns(featureSwitch);
-
-            Femah.Configure()
-                .FeatureSwitchEnum(typeof(FeatureSwitches))
-                .Provider(providerMock.Object)
-                .Initialise();
-
-            //Act
-            ApiResponse apiResponse;
-            using (var apiResponseBuilder = new ApiResponseBuilder())
-            {
-                apiResponse = apiResponseBuilder.CreateWithUpdatedFeatureSwitch(featureSwitch);
-            }
-
-            //Assert
-            Assert.AreEqual((int)HttpStatusCode.NotModified, apiResponse.HttpStatusCode);
-            Assert.AreEqual(string.Empty, apiResponse.Body);
-        }
-
+        
         [Test]
         public void ApiResponseBuilderSetsHttpStatusCodeTo200AndReturnsDesiredFeatureSwitchStateIfPutRequestIncludesFeatureSwitchChangesToIsEnabledState()
         {

--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -114,50 +114,7 @@ namespace Femah.Core.Tests
         #endregion
 
         #region ApiResponseBuilder
-        [Test]
-        public void ApiResponseBuilderSetsHttpStatusCodeTo200AndReturnsDesiredFeatureSwitchStateIfPutRequestIncludesFeatureSwitchChangesToCustomParameters()
-        {
-            //Arrange
-            const string validFeatureType = "Femah.Core.FeatureSwitchTypes.PercentageFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null";
-            const string jsonResponse = "{\"PercentageOn\":75,\"Description\":\"A simple feature switch that is on for a set percentage of users. The state of the switch is persisted in the user's cookies.If no cookie exists the state is chosen at random (weighted according to the percentage), and then stored in a cookie.\",\"ConfigurationInstructions\":\"Set PercentageOn to the percentage of users who should see this feature. Eg. 10 means the feature is on for 10% of users.\",\"IsEnabled\":true,\"Name\":\"TestFeatureSwitch1\",\"FeatureType\":\"Femah.Core.FeatureSwitchTypes.PercentageFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null\"}";
-                    
-            var currentFeatureSwitchState = new PercentageFeatureSwitch
-            {
-                Name = "TestFeatureSwitch1",
-                FeatureType = validFeatureType,
-                IsEnabled = true,
-                PercentageOn = 50
-            };
-
-            var desiredFeatureSwitchState = new PercentageFeatureSwitch
-            {
-                Name = "TestFeatureSwitch1",
-                FeatureType = validFeatureType,
-                IsEnabled = true,
-                PercentageOn = 75
-            };
-
-            var providerMock = new Mock<IFeatureSwitchProvider>();
-            providerMock.Setup(p => p.Get("TestFeatureSwitch1"))
-                .Returns(currentFeatureSwitchState);
-
-            Femah.Configure()
-                .FeatureSwitchEnum(typeof(FeatureSwitches))
-                .Provider(providerMock.Object)
-                .Initialise();
-
-            //Act
-            ApiResponse apiResponse;
-            using (var apiResponseBuilder = new ApiResponseBuilder())
-            {
-                apiResponse = apiResponseBuilder.CreateWithUpdatedFeatureSwitch(desiredFeatureSwitchState);
-            }
-
-            //Assert
-            Assert.AreEqual((int)HttpStatusCode.OK, apiResponse.HttpStatusCode);
-            Assert.AreEqual(jsonResponse, apiResponse.Body);
-        }
-
+       
         [Test]
         [Ignore("Can't currently mock Femah easily, seeing as it's both sealed and the methods we're interested in are internal static, thoughts?")]
         public void AssertApiResponseBuilderCallsUpdateOnFeatureTypeStateIsEnabledStateAndAttributes()

--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -115,56 +115,7 @@ namespace Femah.Core.Tests
 
         #region ApiResponseBuilder
        
-        [Test]
-        [Ignore("Can't currently mock Femah easily, seeing as it's both sealed and the methods we're interested in are internal static, thoughts?")]
-        public void AssertApiResponseBuilderCallsUpdateOnFeatureTypeStateIsEnabledStateAndAttributes()
-        {
-            //Arrange
-            const string validFeatureType = "Femah.Core.FeatureSwitchTypes.PercentageFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null";
-            //const string jsonResponse = "{\"PercentageOn\":75,\"Description\":\"A simple feature switch that is on for a set percentage of users. The state of the switch is persisted in the user's cookies.If no cookie exists the state is chosen at random (weighted according to the percentage), and then stored in a cookie.\",\"ConfigurationInstructions\":\"Set PercentageOn to the percentage of users who should see this feature. Eg. 10 means the feature is on for 10% of users.\",\"IsEnabled\":true,\"Name\":\"TestFeatureSwitch1\",\"FeatureType\":\"Femah.Core.FeatureSwitchTypes.PercentageFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null\"}";
-
-            var currentFeatureSwitchState = new PercentageFeatureSwitch
-            {
-                Name = "TestFeatureSwitch1",
-                FeatureType = validFeatureType,
-                IsEnabled = true,
-                PercentageOn = 50
-            };
-
-            var desiredFeatureSwitchState = new PercentageFeatureSwitch
-            {
-                Name = "TestFeatureSwitch1",
-                FeatureType = validFeatureType,
-                IsEnabled = true,
-                PercentageOn = 75
-            };
-
-            var providerMock = new Mock<IFeatureSwitchProvider>();
-            providerMock.Setup(p => p.Get("TestFeatureSwitch1"))
-                .Returns(currentFeatureSwitchState);
-
-            var femahMock = new Mock<Femah>();
-            //femahMock.Setup(f => f)
-            //TODO: Can't currently mock Femah easily, seeing as it's both sealed and the methods we're interested in are internal static, thoughts?
-
-
-            Femah.Configure()
-                .FeatureSwitchEnum(typeof(FeatureSwitches))
-                .Provider(providerMock.Object)
-                .Initialise();
-
-            //Act
-            ApiResponse apiResponse;
-            using (var apiResponseBuilder = new ApiResponseBuilder())
-            {
-                apiResponse = apiResponseBuilder.CreateWithUpdatedFeatureSwitch(desiredFeatureSwitchState);
-            }
-
-            //Assert
-            //Assert.AreEqual((int)HttpStatusCode.OK, apiResponse.HttpStatusCode);
-            //Assert.AreEqual(jsonResponse, apiResponse.Body);
-            
-        }
+        
 
         #endregion
 

--- a/Femah.Core.Tests/FemahApiTests.cs
+++ b/Femah.Core.Tests/FemahApiTests.cs
@@ -114,52 +114,6 @@ namespace Femah.Core.Tests
         #endregion
 
         #region ApiResponseBuilder
-
-        
-        [Test]
-        public void ApiResponseBuilderSetsHttpStatusCodeTo200AndReturnsDesiredFeatureSwitchStateIfPutRequestIncludesFeatureSwitchChangesToIsEnabledState()
-        {
-            //Arrange
-            const string validFeatureType = "Femah.Core.FeatureSwitchTypes.SimpleFeatureSwitch, Femah.Core, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null";
-            string jsonRequestAndResponse = string.Format(
-                    "{{\"IsEnabled\":false,\"Name\":\"TestFeatureSwitch1\",\"FeatureType\":\"{0}\",\"Description\":\"Define a short description of the feature switch type here.\",\"ConfigurationInstructions\":\"Add configuration context and instructions to be displayed in the admin UI\"}}",
-                    validFeatureType);
-
-            var currentFeatureSwitchState = new SimpleFeatureSwitch
-            {
-                Name = "TestFeatureSwitch1",
-                IsEnabled = true,
-                FeatureType = validFeatureType,
-            };
-
-            var desiredFeatureSwitchState = new SimpleFeatureSwitch
-            {
-                Name = "TestFeatureSwitch1",
-                IsEnabled = false,
-                FeatureType = validFeatureType
-            };
-
-            var providerMock = new Mock<IFeatureSwitchProvider>();
-            providerMock.Setup(p => p.Get("TestFeatureSwitch1"))
-                .Returns(currentFeatureSwitchState);
-
-            Femah.Configure()
-                .FeatureSwitchEnum(typeof(FeatureSwitches))
-                .Provider(providerMock.Object)
-                .Initialise();
-
-            //Act
-            ApiResponse apiResponse;
-            using (var apiResponseBuilder = new ApiResponseBuilder())
-            {
-                apiResponse = apiResponseBuilder.CreateWithUpdatedFeatureSwitch(desiredFeatureSwitchState);
-            }
-
-            //Assert
-            Assert.AreEqual((int)HttpStatusCode.OK, apiResponse.HttpStatusCode);
-            Assert.AreEqual(jsonRequestAndResponse, apiResponse.Body);
-        }
-
         [Test]
         public void ApiResponseBuilderSetsHttpStatusCodeTo200AndReturnsDesiredFeatureSwitchStateIfPutRequestIncludesFeatureSwitchChangesToCustomParameters()
         {


### PR DESCRIPTION
Moved API Response Builder tests over to their own class
